### PR TITLE
feat: add auto terminal provider detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ See [DEVELOPMENT.md](./DEVELOPMENT.md) for build instructions and development gu
     terminal = {
       split_side = "right",
       split_width_percentage = 0.3,
-      provider = "snacks", -- or "native"
+      provider = "auto", -- "auto" (default), "snacks", or "native"
       auto_close = true, -- Auto-close terminal after command completion
     },
 

--- a/lua/claudecode/init.lua
+++ b/lua/claudecode/init.lua
@@ -74,7 +74,7 @@ M.state = {
 ---@alias ClaudeCode.TerminalOpts { \
 ---  split_side?: "left"|"right", \
 ---  split_width_percentage?: number, \
----  provider?: "snacks"|"native", \
+---  provider?: "auto"|"snacks"|"native", \
 ---  show_native_term_exit_tip?: boolean }
 ---
 ---@alias ClaudeCode.SetupOpts { \

--- a/lua/claudecode/terminal.lua
+++ b/lua/claudecode/terminal.lua
@@ -18,7 +18,7 @@ local claudecode_server_module = require("claudecode.server.init")
 local config = {
   split_side = "right",
   split_width_percentage = 0.30,
-  provider = "snacks",
+  provider = "auto",
   show_native_term_exit_tip = true,
   terminal_cmd = nil,
   auto_close = true,
@@ -48,7 +48,15 @@ end
 local function get_provider()
   local logger = require("claudecode.logger")
 
-  if config.provider == "snacks" then
+  if config.provider == "auto" then
+    -- Try snacks first, then fallback to native silently
+    local snacks_provider = load_provider("snacks")
+    if snacks_provider and snacks_provider.is_available() then
+      logger.debug("terminal", "Auto-detected snacks terminal provider")
+      return snacks_provider
+    end
+    -- Fall through to native provider
+  elseif config.provider == "snacks" then
     local snacks_provider = load_provider("snacks")
     if snacks_provider and snacks_provider.is_available() then
       return snacks_provider


### PR DESCRIPTION
## Summary
• Adds automatic terminal provider detection that tries snacks first, falls back to native
• Updates default config from "snacks" to "auto" for better UX
• Eliminates need for users to manually configure terminal provider