### PR TITLE
feat: make diff keymaps adjustable via LazyVim spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,11 +170,11 @@ The diff keymaps are configured in the LazyVim spec and can be customized by mod
   config = true,
   keys = {
     -- ... other keymaps ...
-    
+
     -- Customize diff keymaps to avoid conflicts (e.g., with debugger)
     { "<leader>ya", "<cmd>ClaudeCodeDiffAccept<cr>", desc = "Accept diff" },
     { "<leader>yn", "<cmd>ClaudeCodeDiffDeny<cr>", desc = "Deny diff" },
-    
+
     -- Or disable them entirely by omitting them from the keys table
   },
 }

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
       desc = "Add file",
       ft = { "NvimTree", "neo-tree", "oil" },
     },
+    -- Diff management
+    { "<leader>da", "<cmd>ClaudeCodeDiffAccept<cr>", desc = "Accept diff" },
+    { "<leader>dq", "<cmd>ClaudeCodeDiffDeny<cr>", desc = "Deny diff" },
   },
 }
 ```
@@ -139,7 +142,7 @@ When Claude proposes changes to your files, the plugin opens a native Neovim dif
 ### Accepting Changes
 
 - **`:w` (save)** - Accept the changes and apply them to your file
-- **`<leader>da`** - Accept the changes using the dedicated keymap
+- **`<leader>da`** - Accept the changes using the dedicated keymap (configured in LazyVim spec)
 
 You can edit the proposed changes in the right-hand diff buffer before accepting them. This allows you to modify Claude's suggestions or make additional tweaks before applying the final version to your file.
 
@@ -148,7 +151,7 @@ Both methods signal Claude Code to apply the changes to your file, after which t
 ### Rejecting Changes
 
 - **`:q` or `:close`** - Close the diff view to reject the changes
-- **`<leader>dq`** - Reject changes using the dedicated keymap
+- **`<leader>dq`** - Reject changes using the dedicated keymap (configured in LazyVim spec)
 - **`:bdelete` or `:bwipeout`** - Delete the diff buffer to reject changes
 
 When you reject changes, the diff view closes and the original file remains unchanged.
@@ -159,12 +162,22 @@ You can also navigate to the Claude Code terminal window and accept or reject di
 
 ### Customizing Diff Keymaps
 
-The default keymaps (`<leader>da` and `<leader>dq`) can be customized by remapping them to the underlying commands:
+The diff keymaps are configured in the LazyVim spec and can be customized by modifying the `keys` table:
 
 ```lua
--- Example: Use different keymaps for diff handling
-vim.keymap.set('n', '<leader>ya', '<cmd>ClaudeCodeDiffAccept<cr>', { desc = 'Accept diff' })
-vim.keymap.set('n', '<leader>yn', '<cmd>ClaudeCodeDiffDeny<cr>', { desc = 'Deny diff' })
+{
+  "coder/claudecode.nvim",
+  config = true,
+  keys = {
+    -- ... other keymaps ...
+    
+    -- Customize diff keymaps to avoid conflicts (e.g., with debugger)
+    { "<leader>ya", "<cmd>ClaudeCodeDiffAccept<cr>", desc = "Accept diff" },
+    { "<leader>yn", "<cmd>ClaudeCodeDiffDeny<cr>", desc = "Deny diff" },
+    
+    -- Or disable them entirely by omitting them from the keys table
+  },
+}
 ```
 
 The commands `ClaudeCodeDiffAccept` and `ClaudeCodeDiffDeny` work only in diff buffers created by the plugin and will show a warning if used elsewhere.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ That's it! For more configuration options, see [Advanced Setup](#advanced-setup)
 - `:ClaudeCodeSend` - Send current visual selection to Claude, or add files from tree explorer
 - `:ClaudeCodeTreeAdd` - Add selected file(s) from tree explorer to Claude context (also available via ClaudeCodeSend)
 - `:ClaudeCodeAdd <file-path> [start-line] [end-line]` - Add a specific file or directory to Claude context by path with optional line range
+- `:ClaudeCodeDiffAccept` - Accept the current diff changes (equivalent to `<leader>da`)
+- `:ClaudeCodeDiffDeny` - Deny/reject the current diff changes (equivalent to `<leader>dq`)
 
 ### Toggle Behavior
 
@@ -154,6 +156,18 @@ When you reject changes, the diff view closes and the original file remains unch
 ### Accepting/Rejecting from Claude Code Terminal
 
 You can also navigate to the Claude Code terminal window and accept or reject diffs directly from within Claude's interface. This provides an alternative way to manage diffs without using the Neovim-specific keymaps.
+
+### Customizing Diff Keymaps
+
+The default keymaps (`<leader>da` and `<leader>dq`) can be customized by remapping them to the underlying commands:
+
+```lua
+-- Example: Use different keymaps for diff handling
+vim.keymap.set('n', '<leader>ya', '<cmd>ClaudeCodeDiffAccept<cr>', { desc = 'Accept diff' })
+vim.keymap.set('n', '<leader>yn', '<cmd>ClaudeCodeDiffDeny<cr>', { desc = 'Deny diff' })
+```
+
+The commands `ClaudeCodeDiffAccept` and `ClaudeCodeDiffDeny` work only in diff buffers created by the plugin and will show a warning if used elsewhere.
 
 ### How It Works
 

--- a/dev-config.lua
+++ b/dev-config.lua
@@ -31,6 +31,10 @@ return {
     { "<leader>ai", "<cmd>ClaudeCodeStatus<cr>", desc = "Claude Status" },
     { "<leader>aS", "<cmd>ClaudeCodeStart<cr>", desc = "Start Claude Server" },
     { "<leader>aQ", "<cmd>ClaudeCodeStop<cr>", desc = "Stop Claude Server" },
+
+    -- Diff management (buffer-local, only active in diff buffers)
+    { "<leader>da", "<cmd>ClaudeCodeDiffAccept<cr>", desc = "Accept diff" },
+    { "<leader>dq", "<cmd>ClaudeCodeDiffDeny<cr>", desc = "Deny diff" },
   },
 
   -- Development configuration - all options shown with defaults commented out

--- a/dev-config.lua
+++ b/dev-config.lua
@@ -33,8 +33,8 @@ return {
     { "<leader>aQ", "<cmd>ClaudeCodeStop<cr>", desc = "Stop Claude Server" },
 
     -- Diff management (buffer-local, only active in diff buffers)
-    { "<leader>da", "<cmd>ClaudeCodeDiffAccept<cr>", desc = "Accept diff" },
-    { "<leader>dq", "<cmd>ClaudeCodeDiffDeny<cr>", desc = "Deny diff" },
+    { "<leader>aa", "<cmd>ClaudeCodeDiffAccept<cr>", desc = "Accept diff" },
+    { "<leader>ad", "<cmd>ClaudeCodeDiffDeny<cr>", desc = "Deny diff" },
   },
 
   -- Development configuration - all options shown with defaults commented out

--- a/lua/claudecode/diff.lua
+++ b/lua/claudecode/diff.lua
@@ -578,23 +578,16 @@ function M._create_diff_view_from_window(target_window, old_file_path, new_buffe
   vim.cmd("wincmd =")
   vim.api.nvim_set_current_win(new_win)
 
+  -- Store diff context in buffer variables for user commands
+  vim.b[new_buffer].claudecode_diff_tab_name = tab_name
+  vim.b[new_buffer].claudecode_diff_new_win = new_win
+  vim.b[new_buffer].claudecode_diff_target_win = target_window
+
   local keymap_opts = { buffer = new_buffer, silent = true }
 
-  vim.keymap.set("n", "<leader>da", function()
-    M._resolve_diff_as_saved(tab_name, new_buffer)
-  end, keymap_opts)
-
-  vim.keymap.set("n", "<leader>dq", function()
-    if vim.api.nvim_win_is_valid(new_win) then
-      vim.api.nvim_win_close(new_win, true)
-    end
-    if vim.api.nvim_win_is_valid(target_window) then
-      vim.api.nvim_set_current_win(target_window)
-      vim.cmd("diffoff")
-    end
-
-    M._resolve_diff_as_rejected(tab_name)
-  end, keymap_opts)
+  -- Use the new user commands instead of inline functions
+  vim.keymap.set("n", "<leader>da", "<cmd>ClaudeCodeDiffAccept<cr>", keymap_opts)
+  vim.keymap.set("n", "<leader>dq", "<cmd>ClaudeCodeDiffDeny<cr>", keymap_opts)
 
   -- Return window information for later storage
   return {
@@ -897,6 +890,45 @@ end
 -- Manual buffer reload function for testing/debugging
 function M.reload_file_buffers_manual(file_path, original_cursor_pos)
   return reload_file_buffers(file_path, original_cursor_pos)
+end
+
+--- Accept the current diff (user command version)
+-- This function reads the diff context from buffer variables
+function M.accept_current_diff()
+  local current_buffer = vim.api.nvim_get_current_buf()
+  local tab_name = vim.b[current_buffer].claudecode_diff_tab_name
+
+  if not tab_name then
+    vim.notify("No active diff found in current buffer", vim.log.levels.WARN)
+    return
+  end
+
+  M._resolve_diff_as_saved(tab_name, current_buffer)
+end
+
+--- Deny/reject the current diff (user command version)
+-- This function reads the diff context from buffer variables
+function M.deny_current_diff()
+  local current_buffer = vim.api.nvim_get_current_buf()
+  local tab_name = vim.b[current_buffer].claudecode_diff_tab_name
+  local new_win = vim.b[current_buffer].claudecode_diff_new_win
+  local target_window = vim.b[current_buffer].claudecode_diff_target_win
+
+  if not tab_name then
+    vim.notify("No active diff found in current buffer", vim.log.levels.WARN)
+    return
+  end
+
+  -- Close windows and clean up (same logic as the original keymap)
+  if new_win and vim.api.nvim_win_is_valid(new_win) then
+    vim.api.nvim_win_close(new_win, true)
+  end
+  if target_window and vim.api.nvim_win_is_valid(target_window) then
+    vim.api.nvim_set_current_win(target_window)
+    vim.cmd("diffoff")
+  end
+
+  M._resolve_diff_as_rejected(tab_name)
 end
 
 return M

--- a/lua/claudecode/diff.lua
+++ b/lua/claudecode/diff.lua
@@ -583,11 +583,6 @@ function M._create_diff_view_from_window(target_window, old_file_path, new_buffe
   vim.b[new_buffer].claudecode_diff_new_win = new_win
   vim.b[new_buffer].claudecode_diff_target_win = target_window
 
-  -- Note: Keymaps for diff accept/deny are now configured in the LazyVim spec
-  -- Users can customize them by adding to their plugin configuration:
-  -- { "<leader>da", "<cmd>ClaudeCodeDiffAccept<cr>", desc = "Accept diff", buffer = true }
-  -- { "<leader>dq", "<cmd>ClaudeCodeDiffDeny<cr>", desc = "Deny diff", buffer = true }
-
   -- Return window information for later storage
   return {
     new_window = new_win,

--- a/lua/claudecode/diff.lua
+++ b/lua/claudecode/diff.lua
@@ -583,11 +583,10 @@ function M._create_diff_view_from_window(target_window, old_file_path, new_buffe
   vim.b[new_buffer].claudecode_diff_new_win = new_win
   vim.b[new_buffer].claudecode_diff_target_win = target_window
 
-  local keymap_opts = { buffer = new_buffer, silent = true }
-
-  -- Use the new user commands instead of inline functions
-  vim.keymap.set("n", "<leader>da", "<cmd>ClaudeCodeDiffAccept<cr>", keymap_opts)
-  vim.keymap.set("n", "<leader>dq", "<cmd>ClaudeCodeDiffDeny<cr>", keymap_opts)
+  -- Note: Keymaps for diff accept/deny are now configured in the LazyVim spec
+  -- Users can customize them by adding to their plugin configuration:
+  -- { "<leader>da", "<cmd>ClaudeCodeDiffAccept<cr>", desc = "Accept diff", buffer = true }
+  -- { "<leader>dq", "<cmd>ClaudeCodeDiffDeny<cr>", desc = "Deny diff", buffer = true }
 
   -- Return window information for later storage
   return {

--- a/lua/claudecode/init.lua
+++ b/lua/claudecode/init.lua
@@ -880,6 +880,21 @@ function M._create_commands()
       "Terminal module not found. Terminal commands (ClaudeCode, ClaudeCodeOpen, ClaudeCodeClose) not registered."
     )
   end
+
+  -- Diff management commands
+  vim.api.nvim_create_user_command("ClaudeCodeDiffAccept", function()
+    local diff = require("claudecode.diff")
+    diff.accept_current_diff()
+  end, {
+    desc = "Accept the current diff changes",
+  })
+
+  vim.api.nvim_create_user_command("ClaudeCodeDiffDeny", function()
+    local diff = require("claudecode.diff")
+    diff.deny_current_diff()
+  end, {
+    desc = "Deny/reject the current diff changes",
+  })
 end
 
 --- Get version information

--- a/tests/mocks/vim.lua
+++ b/tests/mocks/vim.lua
@@ -582,6 +582,25 @@ local vim = {
     end,
   }),
 
+  b = setmetatable({}, {
+    __index = function(_, bufnr)
+      -- Return buffer-local variables for the given buffer
+      if vim._buffers[bufnr] then
+        if not vim._buffers[bufnr].b_vars then
+          vim._buffers[bufnr].b_vars = {}
+        end
+        return vim._buffers[bufnr].b_vars
+      end
+      return {}
+    end,
+    __newindex = function(_, bufnr, vars)
+      -- Set buffer-local variables for the given buffer
+      if vim._buffers[bufnr] then
+        vim._buffers[bufnr].b_vars = vars
+      end
+    end,
+  }),
+
   deepcopy = function(tbl)
     if type(tbl) ~= "table" then
       return tbl


### PR DESCRIPTION
## Summary

This implements adjustable diff keymaps by moving them from hardcoded buffer-local keymaps to the LazyVim spec configuration, allowing users to customize or disable diff handling keymaps that may conflict with debugger mappings.

## Key Changes

- **Added user commands**: `ClaudeCodeDiffAccept` and `ClaudeCodeDiffDeny` to provide the underlying diff functionality
- **Moved keymaps to LazyVim spec**: Users can now customize diff keymaps in their plugin configuration instead of being stuck with hardcoded `<leader>da`/`<leader>dq`
- **Updated documentation**: Added examples showing how to customize or disable diff keymaps to avoid conflicts
- **Fixed test infrastructure**: Added `vim.b` mock to resolve test failures when diff operations store buffer-local variables
- **Updated dev config**: Changed to non-conflicting keymaps (`<leader>aa`/`<leader>ad`) as an example

## Usage

Users can now customize like this:
```lua
-- Avoid debugger conflicts
{ "<leader>ya", "<cmd>ClaudeCodeDiffAccept<cr>", desc = "Accept diff" },
{ "<leader>yn", "<cmd>ClaudeCodeDiffDeny<cr>", desc = "Deny diff" },
```

Or disable entirely by omitting the keymaps from their configuration.

Closes #44