### PR TITLE
feat: add CLAUDE_CONFIG_DIR environment variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ This plugin creates a WebSocket server that Claude Code CLI connects to, impleme
 The protocol uses a WebSocket-based variant of MCP (Model Context Protocol) that:
 
 1. Creates a WebSocket server on a random port
-2. Writes a lock file to `~/.claude/ide/[port].lock` with connection info
+2. Writes a lock file to `~/.claude/ide/[port].lock` (or `$CLAUDE_CONFIG_DIR/ide/[port].lock` if `CLAUDE_CONFIG_DIR` is set) with connection info
 3. Sets environment variables that tell Claude where to connect
 4. Implements MCP tools that Claude can call
 
@@ -176,7 +176,7 @@ For deep technical details, see [ARCHITECTURE.md](./ARCHITECTURE.md).
 
 ## Troubleshooting
 
-- **Claude not connecting?** Check `:ClaudeCodeStatus` and verify lock file exists in `~/.claude/ide/`
+- **Claude not connecting?** Check `:ClaudeCodeStatus` and verify lock file exists in `~/.claude/ide/` (or `$CLAUDE_CONFIG_DIR/ide/` if `CLAUDE_CONFIG_DIR` is set)
 - **Need debug logs?** Set `log_level = "debug"` in opts
 - **Terminal issues?** Try `provider = "native"` if using snacks.nvim
 

--- a/lua/claudecode/lockfile.lua
+++ b/lua/claudecode/lockfile.lua
@@ -7,7 +7,17 @@
 local M = {}
 
 --- Path to the lock file directory
-M.lock_dir = vim.fn.expand("~/.claude/ide")
+---@return string lock_dir The path to the lock file directory
+local function get_lock_dir()
+  local claude_config_dir = os.getenv("CLAUDE_CONFIG_DIR")
+  if claude_config_dir and claude_config_dir ~= "" then
+    return vim.fn.expand(claude_config_dir .. "/ide")
+  else
+    return vim.fn.expand("~/.claude/ide")
+  end
+end
+
+M.lock_dir = get_lock_dir()
 
 -- Track if random seed has been initialized
 local random_initialized = false

--- a/scripts/lib_claude.sh
+++ b/scripts/lib_claude.sh
@@ -3,7 +3,11 @@
 # This library provides reusable functions for interacting with Claude Code's WebSocket API
 
 # Configuration
-export CLAUDE_LOCKFILE_DIR="$HOME/.claude/ide"
+if [ -n "$CLAUDE_CONFIG_DIR" ]; then
+  export CLAUDE_LOCKFILE_DIR="$CLAUDE_CONFIG_DIR/ide"
+else
+  export CLAUDE_LOCKFILE_DIR="$HOME/.claude/ide"
+fi
 export CLAUDE_LOG_DIR="mcp_test_logs" # Default log directory
 export CLAUDE_WS_TIMEOUT=10           # Default timeout in seconds
 
@@ -13,7 +17,7 @@ export CLAUDE_WS_TIMEOUT=10           # Default timeout in seconds
 # Find the Claude lockfile and extract the port
 find_claude_lockfile() {
   # Get all .lock files
-  lock_files=$(find ~/.claude/ide -name "*.lock" 2>/dev/null || echo "")
+  lock_files=$(find "$CLAUDE_LOCKFILE_DIR" -name "*.lock" 2>/dev/null || echo "")
 
   if [ -z "$lock_files" ]; then
     echo "No Claude lockfiles found. Is the VSCode extension running?" >&2


### PR DESCRIPTION
## Summary

This PR adds support for the `CLAUDE_CONFIG_DIR` environment variable, allowing users to customize
 the Claude configuration directory location.

## Motivation

- While not documented officially, `CLAUDE_CONFIG_DIR` can change the configuration directory, and
 some users (including myself) are already using this setting.
- Though there's no official announcement, it has been reported that in versions v1.0.28 and
above, the default configuration directory may have changed from `~/.claude/ide/` to
`~/.config/claude/ide/`.
  - This might be a temporary issue, but users can use this setting as a temporary workaround.
  - Reference: https://github.com/anthropics/claude-code/issues/2277

## Note

Due to issues with my personal nix environment, I was unable to run tests locally.
