### PR TITLE
fix: do not wipe claude buffer on window close (native)

### DIFF
--- a/lua/claudecode/terminal/native.lua
+++ b/lua/claudecode/terminal/native.lua
@@ -125,7 +125,7 @@ local function open_terminal(cmd_string, env_table, effective_config, focus)
 
   winid = new_winid
   bufnr = vim.api.nvim_get_current_buf()
-  vim.bo[bufnr].bufhidden = "wipe" -- Wipe buffer when hidden (e.g., window closed)
+  vim.bo[bufnr].bufhidden = "hide"
   -- buftype=terminal is set by termopen
 
   if focus then
@@ -185,9 +185,6 @@ end
 local function hide_terminal()
   -- Hide the terminal window but keep the buffer and job alive
   if bufnr and vim.api.nvim_buf_is_valid(bufnr) and winid and vim.api.nvim_win_is_valid(winid) then
-    -- Set buffer to hide instead of being wiped when window closes
-    vim.api.nvim_buf_set_option(bufnr, "bufhidden", "hide")
-
     -- Close the window - this preserves the buffer and job
     vim.api.nvim_win_close(winid, false)
     winid = nil -- Clear window reference

--- a/tests/unit/native_terminal_toggle_spec.lua
+++ b/tests/unit/native_terminal_toggle_spec.lua
@@ -283,7 +283,7 @@ describe("claudecode.terminal.native toggle behavior", function()
 
       -- Verify initial state - buffer should exist and have a window
       assert.is_not_nil(mock_state.buffers[initial_bufnr])
-      assert.are.equal("wipe", mock_state.buffers[initial_bufnr].options.bufhidden)
+      assert.are.equal("hide", mock_state.buffers[initial_bufnr].options.bufhidden)
 
       -- Find the window that contains our terminal buffer
       local terminal_winid = nil
@@ -306,10 +306,7 @@ describe("claudecode.terminal.native toggle behavior", function()
       assert.are.equal(initial_bufnr, native_provider.get_active_bufnr())
       assert.is_not_nil(mock_state.buffers[initial_bufnr])
 
-      -- 2. bufhidden should have been set to "hide" (this is the core fix)
-      assert.are.equal("hide", mock_state.buffer_options[initial_bufnr].bufhidden)
-
-      -- 3. Window should be closed/invalid
+      -- 2. Window should be closed/invalid
       assert.is_nil(mock_state.windows[terminal_winid])
     end)
 
@@ -383,7 +380,6 @@ describe("claudecode.terminal.native toggle behavior", function()
       -- Toggle should hide but preserve process
       native_provider.toggle(cmd_string, env_table, config)
       assert.are.equal(initial_bufnr, native_provider.get_active_bufnr())
-      assert.are.equal("hide", mock_state.buffer_options[initial_bufnr].bufhidden)
 
       -- Close should kill the process (cleanup_state called)
       native_provider.close()
@@ -415,8 +411,7 @@ describe("claudecode.terminal.native toggle behavior", function()
       mock_state.current_win = 1 -- Different window
       native_provider.simple_toggle(cmd_string, env_table, config)
 
-      -- Should have hidden the terminal (set bufhidden=hide and closed window)
-      assert.are.equal("hide", mock_state.buffer_options[initial_bufnr].bufhidden)
+      -- Should have hidden the terminal (closed window)
       assert.is_nil(mock_state.windows[terminal_winid])
     end)
 
@@ -530,7 +525,6 @@ describe("claudecode.terminal.native toggle behavior", function()
       native_provider.focus_toggle(cmd_string, env_table, config)
 
       -- Should have hidden the terminal
-      assert.are.equal("hide", mock_state.buffer_options[initial_bufnr].bufhidden)
       assert.is_nil(mock_state.windows[terminal_winid])
     end)
   end)


### PR DESCRIPTION
## Summary

The `native` provider had a behavior where closing the claude window wiped the buffer, rather than hiding it, which is different from the snacks behavior. It means it was very easy to accidentally terminate the session when trying to hide the buffer.

This changes it so the buffer is hidden on close instead, behaving like `snacks`