### PR TITLE
feat: add close_on_exit terminal configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ For deep technical details, see [ARCHITECTURE.md](./ARCHITECTURE.md).
       split_width_percentage = 0.30,
       provider = "auto", -- "auto", "snacks", or "native"
       auto_close = true,
+      close_on_exit = true, -- Close terminal window when process exits
     },
 
     -- Diff Integration

--- a/lua/claudecode/terminal.lua
+++ b/lua/claudecode/terminal.lua
@@ -24,6 +24,7 @@ local config = {
   show_native_term_exit_tip = true,
   terminal_cmd = nil,
   auto_close = true,
+  close_on_exit = true, -- When true, closes terminal window when process exits
 }
 
 -- Lazy load providers
@@ -102,6 +103,7 @@ local function build_config(opts_override)
     split_side = effective_config.split_side,
     split_width_percentage = effective_config.split_width_percentage,
     auto_close = effective_config.auto_close,
+    close_on_exit = effective_config.close_on_exit,
   }
 end
 
@@ -209,6 +211,8 @@ function M.setup(user_term_config, p_terminal_cmd)
       elseif k == "show_native_term_exit_tip" and type(v) == "boolean" then
         config[k] = v
       elseif k == "auto_close" and type(v) == "boolean" then
+        config[k] = v
+      elseif k == "close_on_exit" and type(v) == "boolean" then
         config[k] = v
       else
         vim.notify("claudecode.terminal.setup: Invalid value for " .. k .. ": " .. tostring(v), vim.log.levels.WARN)

--- a/lua/claudecode/terminal/native.lua
+++ b/lua/claudecode/terminal/native.lua
@@ -98,6 +98,10 @@ local function open_terminal(cmd_string, env_table, effective_config, focus)
 
           cleanup_state() -- Clear our managed state first
 
+          if not effective_config.close_on_exit then
+            return
+          end
+
           if current_winid_for_job and vim.api.nvim_win_is_valid(current_winid_for_job) then
             if current_bufnr_for_job and vim.api.nvim_buf_is_valid(current_bufnr_for_job) then
               -- Optional: Check if the window still holds the same terminal buffer

--- a/lua/claudecode/terminal/snacks.lua
+++ b/lua/claudecode/terminal/snacks.lua
@@ -29,7 +29,9 @@ local function setup_terminal_events(term_instance, config)
       -- Clean up
       terminal = nil
       vim.schedule(function()
-        term_instance:close({ buf = true })
+        if config.close_on_exit then
+          term_instance:close({ buf = true })
+        end
         vim.cmd.checktime()
       end)
     end, { buf = true })


### PR DESCRIPTION
## Summary

Add a new `close_on_exit` terminal configuration option that controls whether the terminal window closes automatically when the Claude process exits.

## Motivation

Claude Code displays valuable spend metrics and usage statistics when the process exits. With the current behavior, the terminal window closes immediately on exit, making these metrics invisible to users. This feature allows users to configure the terminal to remain open so they can review this important information.

## Changes

- **New Configuration Option**: Add `close_on_exit` boolean property to terminal settings (defaults to `true` for backward compatibility)
- **Provider Support**: Implement early return logic in both Snacks and native terminal providers
- **Documentation**: Update README with the new configuration option and usage example

## Usage

```lua
{
  "coder/claudecode.nvim",
  opts = {
    terminal = {
      close_on_exit = false, -- Keep terminal open to see spend metrics
    },
  },
}
```

## Test Plan

- [x] Test with `close_on_exit = true` (default) - terminal closes on exit
- [x] Test with `close_on_exit = false` - terminal stays open on exit  
- [x] Test with both snacks and native terminal providers
- [x] Verify backward compatibility with existing configurations
- [x] Confirm spend metrics are visible when terminal remains open

## Benefits

- Users can now see Claude's spend metrics and final output
- Helpful for monitoring API usage and costs
- Maintains backward compatibility
- Simple configuration option that's easy to understand