### PR TITLE
fix(snacks): invalid window on `:ClaudeCodeFocus`

### DIFF
--- a/lua/claudecode/terminal/snacks.lua
+++ b/lua/claudecode/terminal/snacks.lua
@@ -167,11 +167,11 @@ function M.simple_toggle(cmd_string, env_table, config)
   local logger = require("claudecode.logger")
 
   -- Check if terminal exists and is visible
-  if terminal and terminal:buf_valid() and terminal.win then
+  if terminal and terminal:buf_valid() and terminal:win_valid() then
     -- Terminal is visible, hide it
     logger.debug("terminal", "Simple toggle: hiding visible terminal")
     terminal:toggle()
-  elseif terminal and terminal:buf_valid() and not terminal.win then
+  elseif terminal and terminal:buf_valid() and not terminal:win_valid() then
     -- Terminal exists but not visible, show it
     logger.debug("terminal", "Simple toggle: showing hidden terminal")
     terminal:toggle()
@@ -195,11 +195,11 @@ function M.focus_toggle(cmd_string, env_table, config)
   local logger = require("claudecode.logger")
 
   -- Terminal exists, is valid, but not visible
-  if terminal and terminal:buf_valid() and not terminal.win then
+  if terminal and terminal:buf_valid() and not terminal:win_valid() then
     logger.debug("terminal", "Focus toggle: showing hidden terminal")
     terminal:toggle()
   -- Terminal exists, is valid, and is visible
-  elseif terminal and terminal:buf_valid() and terminal.win then
+  elseif terminal and terminal:buf_valid() and terminal:win_valid() then
     local claude_term_neovim_win_id = terminal.win
     local current_neovim_win_id = vim.api.nvim_get_current_win()
 


### PR DESCRIPTION
Steps to reproduce:

1. `:ClaudeCode` to open claude code
2. `<c-h>` to focus main window
3. `<c-w>o` in main window to close claude code
4. `:ClaudeCodeFocus` to focus claude code

I got:

```
Lua :command callback: .../lazy/claudecode.nvim/lua/claudecode/terminal/snacks.lua:213: Invalid window id: 1010
stack traceback:
 [C]: in function 'nvim_set_current_win'
 .../lazy/claudecode.nvim/lua/claudecode/terminal/snacks.lua:213: in function 'focus_toggle'
 ...re/nvim/lazy/claudecode.nvim/lua/claudecode/terminal.lua:257: in function 'focus_toggle'
 .../share/nvim/lazy/claudecode.nvim/lua/claudecode/init.lua:905: in function <.../share/nvim/lazy/claudecode.nvim/lua/claudecode/init.lua:899>
```

Config:

```lua
{
    "coder/claudecode.nvim",
    dependencies = { "folke/snacks.nvim" },
    cmd = "ClaudeCode",
    init = function()
      vim.env.CLAUDE_CONFIG_DIR = vim.fn.expand("~/.config/claude")
    end,
    opts = {},
}
```