### PR TITLE
feat(snacks): add `snacks_win_opts` for user to override opts of `Snacks.terminal.open()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ For deep technical details, see [ARCHITECTURE.md](./ARCHITECTURE.md).
       split_width_percentage = 0.30,
       provider = "auto", -- "auto", "snacks", or "native"
       auto_close = true,
+      snacks_win_opts = {}, -- Opts to pass to `Snacks.terminal.open()`
     },
 
     -- Diff Integration

--- a/dev-config.lua
+++ b/dev-config.lua
@@ -70,6 +70,7 @@ return {
     --   provider = "auto",                        -- "auto", "snacks", or "native"
     --   show_native_term_exit_tip = true,         -- Show exit tip for native terminal
     --   auto_close = true,                        -- Auto-close terminal after command completion
+    --   snacks_win_opts = {},                     -- Opts to pass to `Snacks.terminal.open()`
     -- },
 
     -- Development overrides (uncomment as needed)

--- a/lua/claudecode/init.lua
+++ b/lua/claudecode/init.lua
@@ -87,7 +87,8 @@ M.state = {
 ---  split_side?: "left"|"right", \
 ---  split_width_percentage?: number, \
 ---  provider?: "auto"|"snacks"|"native", \
----  show_native_term_exit_tip?: boolean }
+---  show_native_term_exit_tip?: boolean, \
+---  snacks_win_opts?: table }
 ---
 ---@alias ClaudeCode.SetupOpts { \
 ---  terminal?: ClaudeCode.TerminalOpts }

--- a/lua/claudecode/terminal.lua
+++ b/lua/claudecode/terminal.lua
@@ -24,6 +24,7 @@ local config = {
   show_native_term_exit_tip = true,
   terminal_cmd = nil,
   auto_close = true,
+  snacks_win_opts = {},
 }
 
 -- Lazy load providers
@@ -91,6 +92,9 @@ local function build_config(opts_override)
       split_width_percentage = function(val)
         return type(val) == "number" and val > 0 and val < 1
       end,
+      snacks_win_opts = function(val)
+        return type(val) == "table"
+      end,
     }
     for key, val in pairs(opts_override) do
       if effective_config[key] ~= nil and validators[key] and validators[key](val) then
@@ -102,6 +106,7 @@ local function build_config(opts_override)
     split_side = effective_config.split_side,
     split_width_percentage = effective_config.split_width_percentage,
     auto_close = effective_config.auto_close,
+    snacks_win_opts = effective_config.snacks_win_opts,
   }
 end
 
@@ -179,6 +184,7 @@ end
 -- @field user_term_config.split_width_percentage number Percentage of screen width (0.0 to 1.0, default: 0.30).
 -- @field user_term_config.provider string 'snacks' or 'native' (default: 'snacks').
 -- @field user_term_config.show_native_term_exit_tip boolean Show tip for exiting native terminal (default: true).
+-- @field user_term_config.snacks_win_opts table Opts to pass to `Snacks.terminal.open()` (default: {}).
 -- @param p_terminal_cmd string|nil The command to run in the terminal (from main config).
 function M.setup(user_term_config, p_terminal_cmd)
   if user_term_config == nil then -- Allow nil, default to empty table silently
@@ -209,6 +215,8 @@ function M.setup(user_term_config, p_terminal_cmd)
       elseif k == "show_native_term_exit_tip" and type(v) == "boolean" then
         config[k] = v
       elseif k == "auto_close" and type(v) == "boolean" then
+        config[k] = v
+      elseif k == "snacks_win_opts" and type(v) == "table" then
         config[k] = v
       else
         vim.notify("claudecode.terminal.setup: Invalid value for " .. k .. ": " .. tostring(v), vim.log.levels.WARN)

--- a/lua/claudecode/terminal/snacks.lua
+++ b/lua/claudecode/terminal/snacks.lua
@@ -54,12 +54,12 @@ local function build_opts(config, env_table, focus)
     start_insert = focus,
     auto_insert = focus,
     auto_close = false,
-    win = {
+    win = vim.tbl_deep_extend("force", {
       position = config.split_side,
       width = config.split_width_percentage,
       height = 0,
       relative = "editor",
-    },
+    }, config.snacks_win_opts or {}),
   }
 end
 


### PR DESCRIPTION
Case:

- Floating window.
- Toggle to show/hide the snacks terminal.

```lua
local toggle_key = "<C-,>"
return {
  {
    "coder/claudecode.nvim",
    keys = {
      { toggle_key, "<cmd>ClaudeCodeFocus<cr>", desc = "Claude Code", mode = { "n", "x" } },
    },
    opts = {
      terminal = {
        ---@module "snacks"
        ---@type snacks.win.Config|{}
        snacks_win_opts = {
          position = "float",
          width = 0.9,
          height = 0.9,
          keys = {
            claude_hide = {
              toggle_key,
              function(self)
                self:hide()
              end,
              mode = "t",
              desc = "Hide",
            },
          },
        },
      },
    },
  },
}
```