### PR TITLE
feat: add bin_path configuration option for Claude binary location

### DIFF
--- a/lua/claudecode/config.lua
+++ b/lua/claudecode/config.lua
@@ -5,6 +5,7 @@ local M = {}
 M.defaults = {
   port_range = { min = 10000, max = 65535 },
   auto_start = true,
+  bin_path = "claude",
   terminal_cmd = nil,
   log_level = "info",
   track_selection = true,
@@ -38,6 +39,8 @@ function M.validate(config)
   assert(type(config.auto_start) == "boolean", "auto_start must be a boolean")
 
   assert(config.terminal_cmd == nil or type(config.terminal_cmd) == "string", "terminal_cmd must be nil or a string")
+
+  assert(type(config.bin_path) == "string" and config.bin_path ~= "", "bin_path must be a non-empty string")
 
   local valid_log_levels = { "trace", "debug", "info", "warn", "error" }
   local is_valid_log_level = false

--- a/lua/claudecode/init.lua
+++ b/lua/claudecode/init.lua
@@ -48,6 +48,7 @@ M.version = {
 local default_config = {
   port_range = { min = 10000, max = 65535 },
   auto_start = true,
+  bin_path = "claude",
   terminal_cmd = nil,
   log_level = "info",
   track_selection = true,
@@ -312,7 +313,7 @@ function M.setup(opts)
     -- Guard in case tests or user replace the module with a minimal stub without `setup`.
     if type(terminal_module.setup) == "function" then
       -- terminal_opts might be nil, which the setup function should handle gracefully.
-      terminal_module.setup(terminal_opts, M.state.config.terminal_cmd)
+      terminal_module.setup(terminal_opts, M.state.config.terminal_cmd, M.state.config.bin_path)
     end
   else
     logger.error("init", "Failed to load claudecode.terminal module for setup.")

--- a/lua/claudecode/terminal.lua
+++ b/lua/claudecode/terminal.lua
@@ -23,6 +23,7 @@ local config = {
   provider = "auto",
   show_native_term_exit_tip = true,
   terminal_cmd = nil,
+  bin_path = "claude",
   auto_close = true,
 }
 
@@ -126,7 +127,7 @@ local function get_claude_command_and_env(cmd_args)
   local cmd_from_config = config.terminal_cmd
   local base_cmd
   if not cmd_from_config or cmd_from_config == "" then
-    base_cmd = "claude" -- Default if not configured
+    base_cmd = config.bin_path or "claude"
   else
     base_cmd = cmd_from_config
   end
@@ -180,7 +181,7 @@ end
 -- @field user_term_config.provider string 'snacks' or 'native' (default: 'snacks').
 -- @field user_term_config.show_native_term_exit_tip boolean Show tip for exiting native terminal (default: true).
 -- @param p_terminal_cmd string|nil The command to run in the terminal (from main config).
-function M.setup(user_term_config, p_terminal_cmd)
+function M.setup(user_term_config, p_terminal_cmd, p_bin_path)
   if user_term_config == nil then -- Allow nil, default to empty table silently
     user_term_config = {}
   elseif type(user_term_config) ~= "table" then -- Warn if it's not nil AND not a table
@@ -196,6 +197,16 @@ function M.setup(user_term_config, p_terminal_cmd)
       vim.log.levels.WARN
     )
     config.terminal_cmd = nil -- Fallback to default behavior
+  end
+
+  if p_bin_path == nil or type(p_bin_path) == "string" then
+    config.bin_path = p_bin_path or "claude"
+  else
+    vim.notify(
+      "claudecode.terminal.setup: Invalid bin_path provided: " .. tostring(p_bin_path) .. ". Using default.",
+      vim.log.levels.WARN
+    )
+    config.bin_path = "claude"
   end
 
   for k, v in pairs(user_term_config) do


### PR DESCRIPTION
## Summary

Adds a new `bin_path` configuration option to specify the path to the Claude binary, addressing issues where users have Claude installed in non-standard locations or use aliases that aren't recognized when Neovim spawns processes.

## Why This Change Is Needed

### The Problem
When users have Claude CLI installed in non-standard locations or use shell aliases, they encounter exit code 127 errors when the plugin tries to spawn the Claude process. This happens because:

1. **Shell aliases don't work in subprocess environments** - When Neovim spawns a process using `vim.loop`, it doesn't load shell aliases
2. **Non-standard installation paths** - Users may have Claude installed in custom locations not in their PATH
3. **Local development setups** - Developers may want to use a specific Claude binary for testing

### Current Workaround Limitations
The existing `terminal_cmd` option requires users to specify the entire command, but this is less intuitive than just pointing to the binary location.

## Implementation Details

- **New config option**: `bin_path` (string, defaults to "claude")
- **Backward compatible**: Existing configurations continue to work unchanged
- **Validation**: Ensures `bin_path` is a non-empty string
- **Precedence**: `terminal_cmd` still takes priority if set, otherwise uses `bin_path`

## Usage Example

```lua
require("claudecode").setup({
  bin_path = "/home/user/.local/bin/claude", -- Point to specific binary
  -- or
  bin_path = "/usr/local/bin/claude-dev",    -- Use development version
})
```

## Test Plan

- [x] Syntax validation passes
- [x] Backward compatibility maintained (existing configs work)
- [x] New configuration validates properly
- [x] Terminal module uses bin_path when terminal_cmd is not set

This resolves the common issue where users get "command not found" errors due to Claude binary location or alias resolution problems.