### PR TITLE
feat: add support for out-of-tree terminal providers

### DIFF
--- a/lua/claudecode/init.lua
+++ b/lua/claudecode/init.lua
@@ -88,7 +88,7 @@ M.state = {
 ---@alias ClaudeCode.TerminalOpts { \
 ---  split_side?: "left"|"right", \
 ---  split_width_percentage?: number, \
----  provider?: "auto"|"snacks"|"native", \
+---  provider?: "auto"|"snacks"|"native"|table, \
 ---  show_native_term_exit_tip?: boolean, \
 ---  snacks_win_opts?: table }
 ---


### PR DESCRIPTION
# Add support for out-of-tree terminal providers

This PR allows creating custom terminal providers for claudecode.nvim by passing a table with required functions instead of using the built-in providers. This enables integration with any terminal plugin.

Key changes:
- Added validation and enhancement of custom provider tables
- Implemented graceful fallback to native provider if custom provider is invalid or unavailable
- Added auto-generation of optional functions for custom providers
- Updated documentation with detailed examples of creating custom providers
- Added comprehensive tests for custom provider functionality

The terminal provider configuration now accepts a table with required functions:
- `setup`: Initialize the terminal provider
- `open`: Open terminal with command and environment
- `close`: Close the terminal
- `simple_toggle`: Simple show/hide toggle
- `focus_toggle`: Smart toggle (focus if not focused, hide if focused)
- `get_active_bufnr`: Return terminal buffer number
- `is_available`: Check if the provider can be used

Optional functions are auto-generated if not provided:
- `toggle`: Defaults to calling simple_toggle for backward compatibility
- `_get_terminal_for_test`: For testing purposes