### PR TITLE
Fix: Debounce update on selection

### DIFF
--- a/lua/claudecode/selection.lua
+++ b/lua/claudecode/selection.lua
@@ -95,7 +95,7 @@ end
 --- Handles mode change events.
 -- Triggers an immediate update of the selection.
 function M.on_mode_changed()
-  M.update_selection()
+  M.debounce_update()
 end
 
 --- Handles text change events.


### PR DESCRIPTION
When using [ergoterm.nvim](https://github.com/waiting-for-dev/ergoterm.nvim) as a terminal, the buffer name is continuously flashing NVIM buffer and terminal buffer name. 
performing a debounce update here solves that.

<img width="242" height="83" alt="image" src="https://github.com/user-attachments/assets/33601a05-55f2-4954-b5fb-6eff45257d1b" />
<img width="206" height="122" alt="image" src="https://github.com/user-attachments/assets/e8c08f89-b403-43dd-b3ae-58adbd871dfd" />
