### PR TITLE
feat: add Claude Haiku model and update type annotations

### DIFF
--- a/lua/claudecode/config.lua
+++ b/lua/claudecode/config.lua
@@ -26,8 +26,9 @@ M.defaults = {
     keep_terminal_focus = false, -- If true, moves focus back to terminal after diff opens
   },
   models = {
-    { name = "Claude Opus 4 (Latest)", value = "opus" },
+    { name = "Claude Opus 4.1 (Latest)", value = "opus" },
     { name = "Claude Sonnet 4 (Latest)", value = "sonnet" },
+    { name = "Claude Haiku 3.5 (Latest)", value = "haiku" },
   },
   terminal = nil, -- Will be lazy-loaded to avoid circular dependency
 }

--- a/lua/claudecode/diff.lua
+++ b/lua/claudecode/diff.lua
@@ -6,10 +6,11 @@ local logger = require("claudecode.logger")
 
 -- Global state management for active diffs
 
-local active_diffs = {}
-local autocmd_group
+---@type ClaudeCodeConfig
 local config
 
+---@type number
+local autocmd_group
 ---Get or create the autocmd group
 local function get_autocmd_group()
   if not autocmd_group then
@@ -112,7 +113,7 @@ local function is_buffer_dirty(file_path)
 end
 
 ---Setup the diff module
----@param user_config table? The configuration passed from init.lua
+---@param user_config ClaudeCodeConfig? The configuration passed from init.lua
 function M.setup(user_config)
   -- Store the configuration for later use
   config = user_config or {}
@@ -335,6 +336,9 @@ function M._open_native_diff(old_file_path, new_file_path, new_file_contents, ta
     temp_file = tmp_file,
   }
 end
+
+---@type table<string, table>
+local active_diffs = {}
 
 ---Register diff state for tracking
 ---@param tab_name string Unique identifier for the diff
@@ -638,7 +642,7 @@ function M._create_diff_view_from_window(target_window, old_file_path, new_buffe
       if terminal_win then
         vim.api.nvim_set_current_win(terminal_win)
       end
-    end, 0)
+    end)
   end
 
   -- Return window information for later storage

--- a/lua/claudecode/server/init.lua
+++ b/lua/claudecode/server/init.lua
@@ -25,7 +25,7 @@ M.state = {
 }
 
 ---Initialize the WebSocket server
----@param config table Configuration options
+---@param config ClaudeCodeConfig Configuration options
 ---@param auth_token string|nil The authentication token for validating connections
 ---@return boolean success Whether server started successfully
 ---@return number|string port_or_error Port number or error message

--- a/lua/claudecode/server/tcp.lua
+++ b/lua/claudecode/server/tcp.lua
@@ -49,7 +49,7 @@ function M.find_available_port(min_port, max_port)
 end
 
 ---Create and start a TCP server
----@param config table Server configuration
+---@param config ClaudeCodeConfig Server configuration
 ---@param callbacks table Callback functions
 ---@param auth_token string|nil Authentication token for validating connections
 ---@return TCPServer|nil server The server object, or nil on error


### PR DESCRIPTION
# Update Claude model options and improve type annotations

This PR updates the available Claude models to include:
- Renamed "Claude Opus 4" to "Claude Opus 4.1 (Latest)"
- Added "Claude Haiku 3.5 (Latest)" as a new model option

Additionally, improves type safety throughout the codebase by:
- Adding proper type annotations for configuration parameters
- Adding explicit types for global variables
- Fixing function parameter types to use `ClaudeCodeConfig` where appropriate
- Properly documenting the `active_diffs` table with type information
- Removing an unnecessary timeout parameter in a callback function