### PR TITLE
feat: redesign diff view with horizontal layout and new tab options

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,6 +289,8 @@ require("claudecode").setup({
 The `diff_opts` configuration allows you to customize diff behavior:
 
 - `keep_terminal_focus` (boolean, default: `false`) - When enabled, keeps focus in the Claude Code terminal when a diff opens instead of moving focus to the diff buffer. This allows you to continue using terminal keybindings like `<CR>` for accepting/rejecting diffs without accidentally triggering other mappings.
+- `open_in_new_tab` (boolean, default: `false`) - Open diffs in a new tab instead of the current tab.
+- `hide_terminal_in_new_tab` (boolean, default: `false`) - When opening diffs in a new tab, do not show the Claude terminal split in that new tab. The terminal remains in the original tab, giving maximum screen estate for reviewing the diff.
 
 **Example use case**: If you frequently use `<CR>` or arrow keys in the Claude Code terminal to accept/reject diffs, enable this option to prevent focus from moving to the diff buffer where `<CR>` might trigger unintended actions.
 
@@ -296,6 +298,8 @@ The `diff_opts` configuration allows you to customize diff behavior:
 require("claudecode").setup({
   diff_opts = {
     keep_terminal_focus = true,  -- If true, moves focus back to terminal after diff opens
+    open_in_new_tab = true,      -- Open diff in a separate tab
+    hide_terminal_in_new_tab = true, -- In the new tab, do not show Claude terminal
     auto_close_on_accept = true,
     show_diff_stats = true,
     vertical_split = true,

--- a/dev-config.lua
+++ b/dev-config.lua
@@ -40,29 +40,29 @@ return {
   },
 
   -- Development configuration - all options shown with defaults commented out
+  ---@type ClaudeCodeConfig
   opts = {
     -- Server Configuration
-    -- port_range = { min = 10000, max = 65535 },  -- WebSocket server port range
-    -- auto_start = true,                          -- Auto-start server on Neovim startup
-    -- log_level = "info",                         -- "trace", "debug", "info", "warn", "error"
-    -- terminal_cmd = nil,                         -- Custom terminal command (default: "claude")
+    -- port_range = { min = 10000, max = 65535 }, -- WebSocket server port range
+    -- auto_start = true, -- Auto-start server on Neovim startup
+    -- log_level = "info", -- "trace", "debug", "info", "warn", "error"
+    -- terminal_cmd = nil, -- Custom terminal command (default: "claude")
 
     -- Selection Tracking
-    -- track_selection = true,                     -- Enable real-time selection tracking
-    -- visual_demotion_delay_ms = 50,             -- Delay before demoting visual selection (ms)
+    -- track_selection = true, -- Enable real-time selection tracking
+    -- visual_demotion_delay_ms = 50, -- Delay before demoting visual selection (ms)
 
     -- Connection Management
-    -- connection_wait_delay = 200,                -- Wait time after connection before sending queued @ mentions (ms)
-    -- connection_timeout = 10000,                 -- Max time to wait for Claude Code connection (ms)
-    -- queue_timeout = 5000,                       -- Max time to keep @ mentions in queue (ms)
+    -- connection_wait_delay = 200, -- Wait time after connection before sending queued @ mentions (ms)
+    -- connection_timeout = 10000, -- Max time to wait for Claude Code connection (ms)
+    -- queue_timeout = 5000, -- Max time to keep @ mentions in queue (ms)
 
     -- Diff Integration
     -- diff_opts = {
-    --   auto_close_on_accept = true,              -- Close diff view after accepting changes
-    --   show_diff_stats = true,                   -- Show diff statistics
-    --   vertical_split = true,                    -- Use vertical split for diffs
-    --   open_in_current_tab = true,               -- Open diffs in current tab vs new tab
-    --   keep_terminal_focus = false,              -- If true, moves focus back to terminal after diff opens
+    --   layout = "horizontal", -- "vertical" or "horizontal" diff layout
+    --   open_in_new_tab = true, -- Open diff in a new tab (false = use current tab)
+    --   keep_terminal_focus = true, -- Keep focus in terminal after opening diff
+    --   hide_terminal_in_new_tab = true, -- Hide Claude terminal in the new diff tab for more review space
     -- },
 
     -- Terminal Configuration

--- a/fixtures/nvim-tree/lazy-lock.json
+++ b/fixtures/nvim-tree/lazy-lock.json
@@ -1,6 +1,6 @@
 {
   "lazy.nvim": { "branch": "main", "commit": "6c3bda4aca61a13a9c63f1c1d1b16b9d3be90d7a" },
-  "nvim-tree.lua": { "branch": "master", "commit": "0a7fcdf3f8ba208f4260988a198c77ec11748339" },
+  "nvim-tree.lua": { "branch": "master", "commit": "0a52012d611f3c1492b8d2aba363fabf734de91d" },
   "nvim-web-devicons": { "branch": "master", "commit": "3362099de3368aa620a8105b19ed04c2053e38c0" },
   "tokyonight.nvim": { "branch": "main", "commit": "057ef5d260c1931f1dffd0f052c685dcd14100a3" }
 }

--- a/lua/claudecode/config.lua
+++ b/lua/claudecode/config.lua
@@ -19,11 +19,10 @@ M.defaults = {
   connection_timeout = 10000, -- Maximum time to wait for Claude Code to connect (milliseconds)
   queue_timeout = 5000, -- Maximum time to keep @ mentions in queue (milliseconds)
   diff_opts = {
-    auto_close_on_accept = true,
-    show_diff_stats = true,
-    vertical_split = true,
-    open_in_current_tab = true, -- Use current tab instead of creating new tab
+    layout = "vertical",
+    open_in_new_tab = false, -- Open diff in a new tab (false = use current tab)
     keep_terminal_focus = false, -- If true, moves focus back to terminal after diff opens
+    hide_terminal_in_new_tab = false, -- If true and opening in a new tab, do not show Claude terminal there
   },
   models = {
     { name = "Claude Opus 4.1 (Latest)", value = "opus" },
@@ -106,12 +105,38 @@ function M.validate(config)
   assert(type(config.queue_timeout) == "number" and config.queue_timeout > 0, "queue_timeout must be a positive number")
 
   assert(type(config.diff_opts) == "table", "diff_opts must be a table")
-  assert(type(config.diff_opts.auto_close_on_accept) == "boolean", "diff_opts.auto_close_on_accept must be a boolean")
-  assert(type(config.diff_opts.show_diff_stats) == "boolean", "diff_opts.show_diff_stats must be a boolean")
-  assert(type(config.diff_opts.vertical_split) == "boolean", "diff_opts.vertical_split must be a boolean")
-  assert(type(config.diff_opts.open_in_current_tab) == "boolean", "diff_opts.open_in_current_tab must be a boolean")
+  -- New diff options (optional validation to allow backward compatibility)
+  if config.diff_opts.layout ~= nil then
+    assert(
+      config.diff_opts.layout == "vertical" or config.diff_opts.layout == "horizontal",
+      "diff_opts.layout must be 'vertical' or 'horizontal'"
+    )
+  end
+  if config.diff_opts.open_in_new_tab ~= nil then
+    assert(type(config.diff_opts.open_in_new_tab) == "boolean", "diff_opts.open_in_new_tab must be a boolean")
+  end
   if config.diff_opts.keep_terminal_focus ~= nil then
     assert(type(config.diff_opts.keep_terminal_focus) == "boolean", "diff_opts.keep_terminal_focus must be a boolean")
+  end
+  if config.diff_opts.hide_terminal_in_new_tab ~= nil then
+    assert(
+      type(config.diff_opts.hide_terminal_in_new_tab) == "boolean",
+      "diff_opts.hide_terminal_in_new_tab must be a boolean"
+    )
+  end
+
+  -- Legacy diff options (accept if present to avoid breaking old configs)
+  if config.diff_opts.auto_close_on_accept ~= nil then
+    assert(type(config.diff_opts.auto_close_on_accept) == "boolean", "diff_opts.auto_close_on_accept must be a boolean")
+  end
+  if config.diff_opts.show_diff_stats ~= nil then
+    assert(type(config.diff_opts.show_diff_stats) == "boolean", "diff_opts.show_diff_stats must be a boolean")
+  end
+  if config.diff_opts.vertical_split ~= nil then
+    assert(type(config.diff_opts.vertical_split) == "boolean", "diff_opts.vertical_split must be a boolean")
+  end
+  if config.diff_opts.open_in_current_tab ~= nil then
+    assert(type(config.diff_opts.open_in_current_tab) == "boolean", "diff_opts.open_in_current_tab must be a boolean")
   end
 
   -- Validate env
@@ -157,6 +182,19 @@ function M.apply(user_config)
       for k, v in pairs(user_config) do
         config[k] = v
       end
+    end
+  end
+
+  -- Backward compatibility: map legacy diff options to new fields if provided
+  if config.diff_opts then
+    local d = config.diff_opts
+    -- Map vertical_split -> layout (only if layout not explicitly set)
+    if d.layout == nil and type(d.vertical_split) == "boolean" then
+      d.layout = d.vertical_split and "vertical" or "horizontal"
+    end
+    -- Map open_in_current_tab -> open_in_new_tab (invert; only if not explicitly set)
+    if d.open_in_new_tab == nil and type(d.open_in_current_tab) == "boolean" then
+      d.open_in_new_tab = not d.open_in_current_tab
     end
   end
 

--- a/lua/claudecode/types.lua
+++ b/lua/claudecode/types.lua
@@ -1,3 +1,4 @@
+---@meta
 ---@brief [[
 --- Centralized type definitions for ClaudeCode.nvim public API.
 --- This module contains all user-facing types and configuration structures.
@@ -14,11 +15,10 @@
 
 -- Diff behavior configuration
 ---@class ClaudeCodeDiffOptions
----@field auto_close_on_accept boolean
----@field show_diff_stats boolean
----@field vertical_split boolean
----@field open_in_current_tab boolean
----@field keep_terminal_focus boolean
+---@field layout ClaudeCodeDiffLayout
+---@field open_in_new_tab boolean Open diff in a new tab (false = use current tab)
+---@field keep_terminal_focus boolean Keep focus in terminal after opening diff
+---@field hide_terminal_in_new_tab boolean Hide Claude terminal in newly created diff tab
 
 -- Model selection option
 ---@class ClaudeCodeModelOption
@@ -27,6 +27,9 @@
 
 -- Log level type alias
 ---@alias ClaudeCodeLogLevel "trace"|"debug"|"info"|"warn"|"error"
+
+-- Diff layout type alias
+---@alias ClaudeCodeDiffLayout "vertical"|"horizontal"
 
 -- Terminal split side positioning
 ---@alias ClaudeCodeSplitSide "left"|"right"

--- a/tests/integration/command_args_spec.lua
+++ b/tests/integration/command_args_spec.lua
@@ -153,10 +153,9 @@ describe("ClaudeCode command arguments integration", function()
               track_selection = true,
               visual_demotion_delay_ms = 50,
               diff_opts = {
-                auto_close_on_accept = true,
-                show_diff_stats = true,
-                vertical_split = true,
-                open_in_current_tab = false,
+                layout = "vertical",
+                open_in_new_tab = true, -- Note: inverted from open_in_current_tab = false
+                keep_terminal_focus = false,
               },
             }, opts or {})
           end,

--- a/tests/unit/config_spec.lua
+++ b/tests/unit/config_spec.lua
@@ -85,10 +85,9 @@ describe("Configuration", function()
       track_selection = false,
       visual_demotion_delay_ms = 50,
       diff_opts = {
-        auto_close_on_accept = true,
-        show_diff_stats = true,
-        vertical_split = true,
-        open_in_current_tab = true,
+        layout = "vertical",
+        open_in_new_tab = false,
+        keep_terminal_focus = false,
       },
       models = {}, -- Empty models array should be rejected
     }
@@ -108,10 +107,9 @@ describe("Configuration", function()
       track_selection = false,
       visual_demotion_delay_ms = 50,
       diff_opts = {
-        auto_close_on_accept = true,
-        show_diff_stats = true,
-        vertical_split = true,
-        open_in_current_tab = true,
+        layout = "vertical",
+        open_in_new_tab = false,
+        keep_terminal_focus = false,
       },
       models = {
         { name = "Test Model" }, -- Missing value field
@@ -151,10 +149,8 @@ describe("Configuration", function()
       connection_timeout = 10000,
       queue_timeout = 5000,
       diff_opts = {
-        auto_close_on_accept = true,
-        show_diff_stats = true,
-        vertical_split = true,
-        open_in_current_tab = true,
+        layout = "vertical",
+        open_in_new_tab = false,
         keep_terminal_focus = true,
       },
       env = {},
@@ -178,10 +174,8 @@ describe("Configuration", function()
       connection_timeout = 10000,
       queue_timeout = 5000,
       diff_opts = {
-        auto_close_on_accept = true,
-        show_diff_stats = true,
-        vertical_split = true,
-        open_in_current_tab = true,
+        layout = "vertical",
+        open_in_new_tab = false,
         keep_terminal_focus = "invalid", -- Should be boolean
       },
       env = {},

--- a/tests/unit/diff_hide_terminal_new_tab_spec.lua
+++ b/tests/unit/diff_hide_terminal_new_tab_spec.lua
@@ -1,0 +1,122 @@
+require("tests.busted_setup")
+
+describe("Diff new-tab with hidden terminal", function()
+  local open_diff_tool = require("claudecode.tools.open_diff")
+  local diff = require("claudecode.diff")
+
+  local test_old_file = "/tmp/claudecode_diff_hide_old.txt"
+  local test_new_file = "/tmp/claudecode_diff_hide_new.txt"
+  local test_tab_name = "hide-term-in-new-tab"
+
+  before_each(function()
+    -- Create a real file so filereadable() returns 1 in mocks
+    local f = io.open(test_old_file, "w")
+    f:write("line1\nline2\n")
+    f:close()
+
+    -- Ensure a clean diff state
+    diff._cleanup_all_active_diffs("test_setup")
+
+    -- Provide minimal config directly to diff module
+    diff.setup({
+      terminal = { split_side = "right", split_width_percentage = 0.30 },
+      diff_opts = {
+        layout = "vertical",
+        open_in_new_tab = true,
+        keep_terminal_focus = false,
+        hide_terminal_in_new_tab = true,
+      },
+    })
+
+    -- Stub terminal provider with a valid terminal buffer (should be ignored due to hide flag)
+    local term_buf = vim.api.nvim_create_buf(false, true)
+    package.loaded["claudecode.terminal"] = {
+      get_active_terminal_bufnr = function()
+        return term_buf
+      end,
+      ensure_visible = function() end,
+    }
+  end)
+
+  after_each(function()
+    os.remove(test_old_file)
+    os.remove(test_new_file)
+    -- Clear stub to avoid side effects
+    package.loaded["claudecode.terminal"] = nil
+    diff._cleanup_all_active_diffs("test_teardown")
+  end)
+
+  it("does not place a terminal split in the new tab when hidden", function()
+    local params = {
+      old_file_path = test_old_file,
+      new_file_path = test_new_file,
+      new_file_contents = "updated content\n",
+      tab_name = test_tab_name,
+    }
+
+    local co = coroutine.create(function()
+      open_diff_tool.handler(params)
+    end)
+
+    -- Start the tool (it will yield waiting for user action)
+    local ok, err = coroutine.resume(co)
+    assert.is_true(ok, tostring(err))
+    assert.equal("suspended", coroutine.status(co))
+
+    -- Inspect active diff metadata
+    local active = diff._get_active_diffs()
+    assert.is_table(active[test_tab_name])
+    assert.is_true(active[test_tab_name].created_new_tab)
+    -- Key assertion: no terminal window was created in the new tab
+    assert.is_nil(active[test_tab_name].terminal_win_in_new_tab)
+
+    -- Resolve to finish the coroutine
+    vim.schedule(function()
+      diff._resolve_diff_as_rejected(test_tab_name)
+    end)
+    vim.wait(100, function()
+      return coroutine.status(co) == "dead"
+    end)
+  end)
+
+  it("wipes the initial unnamed buffer created by tabnew", function()
+    local params = {
+      old_file_path = test_old_file,
+      new_file_path = test_new_file,
+      new_file_contents = "updated content\n",
+      tab_name = test_tab_name,
+    }
+
+    -- Start handler
+    local co = coroutine.create(function()
+      open_diff_tool.handler(params)
+    end)
+
+    local ok, err = coroutine.resume(co)
+    assert.is_true(ok, tostring(err))
+    assert.equal("suspended", coroutine.status(co))
+
+    -- After diff opens, the initial unnamed buffer in the new tab should be gone
+    -- because plugin marks it bufhidden=wipe and then replaces it
+    local unnamed_count = 0
+    for _, buf in pairs(vim._buffers) do
+      if buf.name == nil or buf.name == "" then
+        unnamed_count = unnamed_count + 1
+      end
+    end
+    -- There may be zero unnamed buffers, or other tests may create scratch buffers with names
+    -- The important assertion is that there is no unnamed buffer with bufhidden=wipe lingering
+    for id, buf in pairs(vim._buffers) do
+      local bh = buf.options and buf.options.bufhidden or nil
+      assert.not_equal("wipe", bh, "Found lingering unnamed buffer with bufhidden=wipe (buf " .. tostring(id) .. ")")
+    end
+
+    -- Cleanup by rejecting
+    vim.schedule(function()
+      diff._resolve_diff_as_rejected(test_tab_name)
+    end)
+    vim.wait(100, function()
+      return coroutine.status(co) == "dead"
+    end)
+  end)
+end)

--- a/tests/unit/diff_mcp_spec.lua
+++ b/tests/unit/diff_mcp_spec.lua
@@ -153,9 +153,10 @@ describe("MCP-compliant diff operations", function()
       end)
       coroutine.resume(co)
 
-      -- Simulate completion
+      -- Simulate completion and explicit close_tab
       vim.schedule(function()
         diff._resolve_diff_as_saved(test_tab_name, 1)
+        diff.close_diff_by_tab_name(test_tab_name)
       end)
 
       vim.wait(1000, function()
@@ -180,9 +181,10 @@ describe("MCP-compliant diff operations", function()
       local mid_autocmd_count = #vim.api.nvim_get_autocmds({ group = "ClaudeCodeMCPDiff" })
       assert.is_true(mid_autocmd_count > initial_autocmd_count, "Autocmds should be created")
 
-      -- Simulate completion
+      -- Simulate completion and explicit close_tab
       vim.schedule(function()
         diff._resolve_diff_as_rejected(test_tab_name)
+        diff.close_diff_by_tab_name(test_tab_name)
       end)
 
       vim.wait(1000, function()
@@ -205,9 +207,10 @@ describe("MCP-compliant diff operations", function()
       -- Verify diff is tracked
       -- Note: This test may need adjustment based on actual buffer creation
 
-      -- Clean up
+      -- Clean up via reject + close_tab
       vim.schedule(function()
         diff._resolve_diff_as_rejected(test_tab_name)
+        diff.close_diff_by_tab_name(test_tab_name)
       end)
 
       vim.wait(1000, function()

--- a/tests/unit/diff_spec.lua
+++ b/tests/unit/diff_spec.lua
@@ -127,9 +127,9 @@ describe("Diff Module", function()
     it("should create diff with correct parameters", function()
       diff.setup({
         diff_opts = {
-          vertical_split = true,
-          show_diff_stats = false,
-          auto_close_on_accept = true,
+          layout = "vertical",
+          open_in_new_tab = false,
+          keep_terminal_focus = false,
         },
       })
 
@@ -182,9 +182,9 @@ describe("Diff Module", function()
     it("should use horizontal split when configured", function()
       diff.setup({
         diff_opts = {
-          vertical_split = false,
-          show_diff_stats = false,
-          auto_close_on_accept = true,
+          layout = "horizontal",
+          open_in_new_tab = false,
+          keep_terminal_focus = false,
         },
       })
 
@@ -209,19 +209,19 @@ describe("Diff Module", function()
 
       expect(result.success).to_be_true()
       local found_split = false
-      local found_vertical_split = false
+      local found_vsplit = false
 
       for _, cmd in ipairs(commands) do
-        if cmd:find("split", 1, true) and not cmd:find("vertical split", 1, true) then
-          found_split = true
+        if cmd:find("vsplit", 1, true) then
+          found_vsplit = true
         end
-        if cmd:find("vertical split", 1, true) then
-          found_vertical_split = true
+        if cmd:find("split", 1, true) and not cmd:find("vsplit", 1, true) then
+          found_split = true
         end
       end
 
-      expect(found_split).to_be_true()
-      expect(found_vertical_split).to_be_false()
+      expect(found_split).to_be_true() -- Should use horizontal split (accepts modifiers like belowright)
+      expect(found_vsplit).to_be_false() -- Should not use vertical split
 
       rawset(io, "open", old_io_open)
     end)

--- a/tests/unit/diff_ui_cleanup_spec.lua
+++ b/tests/unit/diff_ui_cleanup_spec.lua
@@ -1,0 +1,119 @@
+require("tests.busted_setup")
+
+local diff = require("claudecode.diff")
+
+describe("Diff UI cleanup behavior", function()
+  local test_old_file = "/tmp/test_ui_cleanup_old.txt"
+  local tab_name = "test_ui_cleanup_tab"
+
+  before_each(function()
+    -- Prepare a dummy file
+    local f = io.open(test_old_file, "w")
+    f:write("line1\nline2\n")
+    f:close()
+
+    -- Reset tabs mock
+    vim._tabs = { [1] = true, [2] = true }
+    vim._current_tabpage = 2 -- Simulate we're on the newly created tab during cleanup
+  end)
+
+  after_each(function()
+    os.remove(test_old_file)
+    -- Ensure cleanup doesn't leave state behind
+    diff._cleanup_all_active_diffs("test_teardown")
+  end)
+
+  it("closes the created new tab on accept only after close_tab is invoked", function()
+    -- Minimal windows/buffers for cleanup paths
+    local new_win = 2001
+    local target_win = 2002
+    vim._windows[new_win] = { buf = 2 }
+    vim._windows[target_win] = { buf = 3 }
+
+    -- Register a pending diff that was opened in a new tab
+    diff._register_diff_state(tab_name, {
+      old_file_path = test_old_file,
+      new_window = new_win,
+      target_window = target_win,
+      new_buffer = 2,
+      original_buffer = 3,
+      original_cursor_pos = { 1, 0 },
+      original_tab_number = 1,
+      created_new_tab = true,
+      new_tab_number = 2,
+      had_terminal_in_original = false,
+      autocmd_ids = {},
+      status = "pending",
+      resolution_callback = function(_) end,
+      is_new_file = false,
+    })
+
+    -- Resolve as saved: should NOT close the tab yet
+    diff._resolve_diff_as_saved(tab_name, 2)
+    assert.is_true(
+      vim._last_command == nil or vim._last_command:match("^tabclose") == nil,
+      "Did not expect ':tabclose' before close_tab tool call"
+    )
+
+    -- Simulate close_tab tool invocation
+    local closed = diff.close_diff_by_tab_name(tab_name)
+    assert.is_true(closed)
+    -- Verify a tabclose command was issued now
+    assert.is_true(
+      type(vim._last_command) == "string" and vim._last_command:match("^tabclose") ~= nil,
+      "Expected a ':tabclose' command to be executed on close_tab"
+    )
+  end)
+
+  it("keeps Claude terminal visible in original tab on reject when previously visible", function()
+    -- Spy on terminal.ensure_visible by preloading a stub module
+    local ensure_calls = 0
+    package.loaded["claudecode.terminal"] = {
+      ensure_visible = function()
+        ensure_calls = ensure_calls + 1
+        return true
+      end,
+      get_active_terminal_bufnr = function()
+        return nil
+      end,
+    }
+
+    -- Minimal windows/buffers for cleanup paths
+    local new_win = 2101
+    local target_win = 2102
+    vim._windows[new_win] = { buf = 4 }
+    vim._windows[target_win] = { buf = 5 }
+
+    -- Register a pending diff that was opened in a new tab, and track that
+    -- the terminal was visible in the original tab when the diff was created
+    diff._register_diff_state(tab_name, {
+      old_file_path = test_old_file,
+      new_window = new_win,
+      target_window = target_win,
+      new_buffer = 4,
+      original_buffer = 5,
+      original_cursor_pos = { 1, 0 },
+      original_tab_number = 1,
+      created_new_tab = true,
+      new_tab_number = 2,
+      had_terminal_in_original = true,
+      autocmd_ids = {},
+      status = "pending",
+      resolution_callback = function(_) end,
+      is_new_file = false,
+    })
+
+    -- Mark as rejected and verify no cleanup yet
+    diff._resolve_diff_as_rejected(tab_name)
+    assert.equals(0, ensure_calls)
+
+    -- Simulate close_tab tool invocation for a pending diff (treated as reject)
+    local closed = diff.close_diff_by_tab_name(tab_name)
+    assert.is_true(closed)
+    -- ensure_visible should have been called exactly once during cleanup
+    assert.equals(1, ensure_calls)
+
+    -- Clear the stub to avoid side effects for other tests
+    package.loaded["claudecode.terminal"] = nil
+  end)
+end)


### PR DESCRIPTION
# Improved Diff View Layout and Configuration

This PR refactors the diff view functionality to provide more flexible layout options and better tab management:

- Added a new `layout` option to replace the previous `vertical_split` boolean, supporting both "vertical" and "horizontal" layouts
- Replaced `open_in_current_tab` with `open_in_new_tab` for more intuitive configuration
- Removed redundant options `auto_close_on_accept` and `show_diff_stats` that were no longer used
- Added proper type annotations for configuration options
- Implemented improved window management when opening diffs in new tabs
- Added terminal window preservation when opening diffs in new tabs
- Improved window option handling to maintain consistent appearance across different layouts
- Enhanced cleanup logic to properly handle both tab-based and window-based diff views
- Updated tests to reflect the new configuration options

These changes make the diff view more customizable while simplifying the configuration interface. Users can now choose between vertical or horizontal layouts and easily open diffs in new tabs while maintaining access to the terminal.