### PR TITLE
feat: add option to control behavior when rejecting new file diffs

### DIFF
--- a/lua/claudecode/config.lua
+++ b/lua/claudecode/config.lua
@@ -23,6 +23,7 @@ M.defaults = {
     open_in_new_tab = false, -- Open diff in a new tab (false = use current tab)
     keep_terminal_focus = false, -- If true, moves focus back to terminal after diff opens
     hide_terminal_in_new_tab = false, -- If true and opening in a new tab, do not show Claude terminal there
+    on_new_file_reject = "keep_empty", -- "keep_empty" leaves an empty buffer; "close_window" closes the placeholder split
   },
   models = {
     { name = "Claude Opus 4.1 (Latest)", value = "opus" },
@@ -122,6 +123,13 @@ function M.validate(config)
     assert(
       type(config.diff_opts.hide_terminal_in_new_tab) == "boolean",
       "diff_opts.hide_terminal_in_new_tab must be a boolean"
+    )
+  end
+  if config.diff_opts.on_new_file_reject ~= nil then
+    assert(
+      type(config.diff_opts.on_new_file_reject) == "string"
+        and (config.diff_opts.on_new_file_reject == "keep_empty" or config.diff_opts.on_new_file_reject == "close_window"),
+      "diff_opts.on_new_file_reject must be 'keep_empty' or 'close_window'"
     )
   end
 

--- a/lua/claudecode/types.lua
+++ b/lua/claudecode/types.lua
@@ -19,6 +19,7 @@
 ---@field open_in_new_tab boolean Open diff in a new tab (false = use current tab)
 ---@field keep_terminal_focus boolean Keep focus in terminal after opening diff
 ---@field hide_terminal_in_new_tab boolean Hide Claude terminal in newly created diff tab
+---@field on_new_file_reject ClaudeCodeNewFileRejectBehavior Behavior when rejecting a new-file diff
 
 -- Model selection option
 ---@class ClaudeCodeModelOption
@@ -30,6 +31,9 @@
 
 -- Diff layout type alias
 ---@alias ClaudeCodeDiffLayout "vertical"|"horizontal"
+
+-- Behavior when rejecting new-file diffs
+---@alias ClaudeCodeNewFileRejectBehavior "keep_empty"|"close_window"
 
 -- Terminal split side positioning
 ---@alias ClaudeCodeSplitSide "left"|"right"

--- a/tests/unit/new_file_reject_then_reopen_spec.lua
+++ b/tests/unit/new_file_reject_then_reopen_spec.lua
@@ -1,0 +1,97 @@
+-- Verifies that rejecting a new-file diff with an empty buffer left open does not crash,
+-- and a subsequent write (diff setup) works again.
+require("tests.busted_setup")
+
+describe("New file diff: reject then reopen", function()
+  local diff
+
+  before_each(function()
+    -- Fresh vim mock state
+    if vim and vim._mock and vim._mock.reset then
+      vim._mock.reset()
+    end
+
+    -- Minimal logger stub
+    package.loaded["claudecode.logger"] = {
+      debug = function() end,
+      error = function() end,
+      info = function() end,
+      warn = function() end,
+    }
+
+    -- Reload diff module cleanly
+    package.loaded["claudecode.diff"] = nil
+    diff = require("claudecode.diff")
+
+    -- Setup config on diff
+    diff.setup({
+      diff_opts = {
+        layout = "vertical",
+        open_in_new_tab = false,
+        keep_terminal_focus = false,
+        on_new_file_reject = "keep_empty", -- default behavior
+      },
+      terminal = {},
+    })
+
+    -- Create an empty unnamed buffer and set it in current window so _create_diff_view_from_window reuses it
+    local empty_buf = vim.api.nvim_create_buf(false, true)
+    -- Ensure name is empty and 'modified' is false
+    vim.api.nvim_buf_set_name(empty_buf, "")
+    vim.api.nvim_buf_set_option(empty_buf, "modified", false)
+
+    -- Make current window use this empty buffer
+    local current_win = vim.api.nvim_get_current_win()
+    vim.api.nvim_win_set_buf(current_win, empty_buf)
+  end)
+
+  it("should reuse empty buffer for new-file diff, not delete it on reject, and allow reopening", function()
+    local tab_name = "✻ [TestNewFile] new.lua ⧉"
+    local params = {
+      old_file_path = "/nonexistent/path/to/new.lua", -- ensure new-file scenario
+      new_file_path = "/tmp/new.lua",
+      new_file_contents = "print('hello')\n",
+      tab_name = tab_name,
+    }
+
+    -- Track current window buffer (the reused empty buffer)
+    local target_win = vim.api.nvim_get_current_win()
+    local reused_buf = vim.api.nvim_win_get_buf(target_win)
+    assert.is_true(vim.api.nvim_buf_is_valid(reused_buf))
+
+    -- 1) Setup the diff (should reuse the empty buffer)
+    local setup_ok, setup_err = pcall(function()
+      diff._setup_blocking_diff(params, function() end)
+    end)
+    assert.is_true(setup_ok, "Diff setup failed unexpectedly: " .. tostring(setup_err))
+
+    -- Verify state registered (ownership may vary based on window conditions)
+    local active = diff._get_active_diffs()
+    assert.is_table(active[tab_name])
+    -- Ensure the original buffer reference exists and is valid
+    assert.is_true(vim.api.nvim_buf_is_valid(active[tab_name].original_buffer))
+
+    -- 2) Reject the diff; cleanup should NOT delete the reused empty buffer
+    diff._resolve_diff_as_rejected(tab_name)
+
+    -- After reject, the diff state should be removed
+    local active_after_reject = diff._get_active_diffs()
+    assert.is_nil(active_after_reject[tab_name])
+
+    -- The reused buffer should still be valid (not deleted)
+    assert.is_true(vim.api.nvim_buf_is_valid(reused_buf))
+
+    -- 3) Setup the diff again with the same conditions; should succeed
+    local setup_ok2, setup_err2 = pcall(function()
+      diff._setup_blocking_diff(params, function() end)
+    end)
+    assert.is_true(setup_ok2, "Second diff setup failed unexpectedly: " .. tostring(setup_err2))
+
+    -- Verify new state exists again
+    local active_again = diff._get_active_diffs()
+    assert.is_table(active_again[tab_name])
+
+    -- Clean up to avoid affecting other tests
+    diff._cleanup_diff_state(tab_name, "test cleanup")
+  end)
+end)


### PR DESCRIPTION
# Add option to control behavior when rejecting new file diffs

This PR adds a new configuration option `on_new_file_reject` that controls what happens when a user rejects a diff for a new file:

- `keep_empty` (default): Leaves the empty buffer in place
- `close_window`: Closes the placeholder split window

Previously, when rejecting a new file diff, the plugin would always try to delete the original buffer. This could cause issues when the buffer was reused from an existing empty buffer, leading to potential crashes when attempting to reopen a diff.

The PR includes:
- New configuration option in `config.lua` with validation
- Type definition in `types.lua`
- Logic in `diff.lua` to track whether the original buffer was created by the plugin
- Only delete the original buffer on reject if it was created by the plugin
- Unit test to verify the fix works correctly

This change improves stability when working with new files and gives users more control over the UI behavior.