### PR TITLE
feat: add PartialClaudeCodeConfig type for better configuration handling

### DIFF
--- a/dev-config.lua
+++ b/dev-config.lua
@@ -40,7 +40,7 @@ return {
   },
 
   -- Development configuration - all options shown with defaults commented out
-  ---@type ClaudeCodeConfig
+  ---@type PartialClaudeCodeConfig
   opts = {
     -- Server Configuration
     -- port_range = { min = 10000, max = 65535 }, -- WebSocket server port range

--- a/lua/claudecode/init.lua
+++ b/lua/claudecode/init.lua
@@ -287,7 +287,7 @@ function M.send_at_mention(file_path, start_line, end_line, context)
 end
 
 ---Set up the plugin with user configuration
----@param opts ClaudeCodeConfig|nil Optional configuration table to override defaults.
+---@param opts PartialClaudeCodeConfig|nil Optional configuration table to override defaults.
 ---@return table module The plugin module
 function M.setup(opts)
   opts = opts or {}

--- a/lua/claudecode/types.lua
+++ b/lua/claudecode/types.lua
@@ -107,6 +107,8 @@
 ---@field enable_broadcast_debouncing_in_tests? boolean
 ---@field terminal ClaudeCodeTerminalConfig?
 
+---@class (partial) PartialClaudeCodeConfig: ClaudeCodeConfig
+
 -- Server interface for main module
 ---@class ClaudeCodeServerFacade
 ---@field start fun(config: ClaudeCodeConfig, auth_token: string|nil): (success: boolean, port_or_error: number|string)


### PR DESCRIPTION
# Introduce PartialClaudeCodeConfig type for better type checking

This PR introduces a new `PartialClaudeCodeConfig` type that extends the existing `ClaudeCodeConfig` type. The type signature for the `setup` function and the dev-config have been updated to use this new type, which better represents that configuration options are partial and can be overridden.

This change improves type checking and makes it clearer that the configuration passed to `setup()` doesn't need to include all possible options.