### PR TITLE
fix: detect system sleep and prevent false keepalive timeouts

### DIFF
--- a/lua/claudecode/server/tcp.lua
+++ b/lua/claudecode/server/tcp.lua
@@ -268,7 +268,10 @@ function M.start_ping_timer(server, interval)
       -- This gives clients a fresh keepalive window since the time jump isn't their fault
       require("claudecode.logger").debug(
         "server",
-        string.format("Detected potential wake from sleep (%.1fs elapsed), resetting client keepalive timers", elapsed / 1000)
+        string.format(
+          "Detected potential wake from sleep (%.1fs elapsed), resetting client keepalive timers",
+          elapsed / 1000
+        )
       )
       for _, client in pairs(server.clients) do
         if client.state == "connected" then


### PR DESCRIPTION
When laptop wakes from sleep, the ping timer's elapsed time exceeds the normal interval. This triggers immediate timeout checks on all clients that haven't responded during the sleep period, causing false disconnections. Reset all client pong timestamps after detecting wake events (>1.5x interval elapsed) to give clients a fresh keepalive window.