### PR TITLE
fix: legacy diff options not working due to merge order

### DIFF
--- a/lua/claudecode/config.lua
+++ b/lua/claudecode/config.lua
@@ -205,12 +205,12 @@ function M.apply(user_config)
   -- Backward compatibility: map legacy diff options to new fields if provided
   if config.diff_opts then
     local d = config.diff_opts
-    -- Map vertical_split -> layout (only if layout not explicitly set)
-    if d.layout == nil and type(d.vertical_split) == "boolean" then
+    -- Map vertical_split -> layout (legacy option takes precedence)
+    if type(d.vertical_split) == "boolean" then
       d.layout = d.vertical_split and "vertical" or "horizontal"
     end
-    -- Map open_in_current_tab -> open_in_new_tab (invert; only if not explicitly set)
-    if d.open_in_new_tab == nil and type(d.open_in_current_tab) == "boolean" then
+    -- Map open_in_current_tab -> open_in_new_tab (legacy option takes precedence)
+    if type(d.open_in_current_tab) == "boolean" then
       d.open_in_new_tab = not d.open_in_current_tab
     end
   end


### PR DESCRIPTION
## Summary

Fixes a bug where the legacy diff options `vertical_split` and `open_in_current_tab` were not working correctly.

## Problem

The backward compatibility mapping was checking if fields were `nil` after merging with defaults, but those fields were already populated by the merge, so the legacy options were never applied.

**Example of broken behavior:**
```lua
require("claudecode").setup({
  diff_opts = {
    vertical_split = false,  -- This was ignored! Always got vertical split
  }
})
```

## Solution

Changed the logic to unconditionally apply legacy option mappings when the legacy options are present. This ensures backward compatibility without complex conditional checks.

**Changes:**
- `vertical_split=false` now correctly sets `layout="horizontal"`
- `vertical_split=true` now correctly sets `layout="vertical"`
- `open_in_current_tab=false` now correctly sets `open_in_new_tab=true`
- `open_in_current_tab=true` now correctly sets `open_in_new_tab=false`

## Testing

Manually tested all scenarios:
- ✅ Legacy options work correctly
- ✅ New options continue to work
- ✅ Default behavior unchanged
- ✅ `make format` passes (no changes needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)