### PR TITLE
fix: bump haiku model version

### DIFF
--- a/lua/claudecode/config.lua
+++ b/lua/claudecode/config.lua
@@ -31,7 +31,7 @@ M.defaults = {
     { name = "Claude Opus 4.1 (Latest)", value = "opus" },
     { name = "Claude Sonnet 4.5 (Latest)", value = "sonnet" },
     { name = "Opusplan: Claude Opus 4.1 (Latest) + Sonnet 4.5 (Latest)", value = "opusplan" },
-    { name = "Claude Haiku 3.5 (Latest)", value = "haiku" },
+    { name = "Claude Haiku 4.5 (Latest)", value = "haiku" },
   },
   terminal = nil, -- Will be lazy-loaded to avoid circular dependency
 }


### PR DESCRIPTION
Updated Haiku model name from `3.5` to `4.5` as since [Oct 15, 2025 release](https://www.anthropic.com/news/claude-haiku-4-5) it's the new latest model.

Actual model name value in claude code is still `haiku`, so I assume nothing else needs to be changed.