### PR TITLE
Also send selection update on BufEnter

### DIFF
--- a/lua/claudecode/selection.lua
+++ b/lua/claudecode/selection.lua
@@ -52,12 +52,12 @@ function M.disable()
 end
 
 ---Creates autocommands for tracking selections.
----Sets up listeners for CursorMoved, CursorMovedI, ModeChanged, and TextChanged events.
+---Sets up listeners for CursorMoved, CursorMovedI, BufEnter, ModeChanged, and TextChanged events.
 ---@local
 function M._create_autocommands()
   local group = vim.api.nvim_create_augroup("ClaudeCodeSelection", { clear = true })
 
-  vim.api.nvim_create_autocmd({ "CursorMoved", "CursorMovedI" }, {
+  vim.api.nvim_create_autocmd({ "CursorMoved", "CursorMovedI", "BufEnter" }, {
     group = group,
     callback = function()
       M.on_cursor_moved()


### PR DESCRIPTION
Selection context wasn't sent when I'm just switching buffers but without making any movements. This fixes the issue by also sending upon BufEnter.