### PR TITLE
Check for substring for selection context fallback logic

### DIFF
--- a/lua/claudecode/selection.lua
+++ b/lua/claudecode/selection.lua
@@ -128,8 +128,8 @@ function M.update_selection()
   local current_buf = vim.api.nvim_get_current_buf()
   local buf_name = vim.api.nvim_buf_get_name(current_buf)
 
-  -- If the buffer name starts with "✻ [Claude Code]", do not update selection
-  if buf_name and string.sub(buf_name, 1, string.len("✻ [Claude Code]")) == "✻ [Claude Code]" then
+  -- If the buffer name starts with "term://" and contains "claude", do not update selection
+  if buf_name and buf_name:match("^term://") and buf_name:lower():find("claude", 1, true) then
     -- Optionally, cancel demotion timer like for the terminal
     if M.state.demotion_timer then
       M.state.demotion_timer:stop()


### PR DESCRIPTION
It is not possible to set Neovim buffer name to "✻ [Claude Code]".

Neovim will always try to convert whatever name given to nvim_buf_set_name to either a url or an absolute path:
https://github.com/neovim/neovim/blob/master/src/nvim/path.c#L1816-L1821

Because of this, the current logic doesn't allow for 3rd party terminal (provider=none) to skip sending the selection context.