### PR TITLE
fix: ide diagnostics without URI schema

### DIFF
--- a/lua/claudecode/tools/get_diagnostics.lua
+++ b/lua/claudecode/tools/get_diagnostics.lua
@@ -47,8 +47,7 @@ local function handler(params)
     diagnostics = vim.diagnostic.get(nil)
   else
     local uri = params.uri
-    -- Strips the file:// scheme
-    local filepath = vim.uri_to_fname(uri)
+    local filepath = vim.startswith(uri, "file://") and vim.uri_to_fname(uri) or uri
 
     -- Get buffer number for the specific file
     local bufnr = vim.fn.bufnr(filepath)

--- a/tests/unit/tools/get_diagnostics_spec.lua
+++ b/tests/unit/tools/get_diagnostics_spec.lua
@@ -48,6 +48,9 @@ describe("Tool: get_diagnostics", function()
       -- Real vim.uri_to_fname throws an error for URIs without proper scheme
       error("URI must contain a scheme: " .. uri)
     end)
+    _G.vim.startswith = function(str, prefix)
+      return str:sub(1, #prefix) == prefix
+    end
   end)
 
   after_each(function()
@@ -58,6 +61,7 @@ describe("Tool: get_diagnostics", function()
     _G.vim.json.encode = nil
     _G.vim.fn.bufnr = nil
     _G.vim.uri_to_fname = nil
+    _G.vim.startswith = nil
     -- Note: We don't nullify _G.vim.lsp or _G.vim.diagnostic entirely
     -- as they are checked for existence.
   end)


### PR DESCRIPTION
Claude (at least Opus 4.5) keeps making this tool call with just the file path, not a full URI with `file://` as the input. The current handler errors in this case, due to vim.uri_to_fname throwing an error.

This change only transforms the path through vim.uri_to_fname if it looks like an actual URI, otherwise leaves it as is. 

Tested and now I get reliable tool calls from claude (and checked that a call with file:// still works too)