### PR TITLE
fix: prevent double-close errors on tcp handle

### DIFF
--- a/lua/claudecode/server/client.lua
+++ b/lua/claudecode/server/client.lua
@@ -216,11 +216,15 @@ function M.close_client(client, code, reason)
     local close_frame = frame.create_close_frame(code, reason)
     client.tcp_handle:write(close_frame, function()
       client.state = "closed"
-      client.tcp_handle:close()
+      if not client.tcp_handle:is_closing() then
+        client.tcp_handle:close()
+      end
     end)
   else
     client.state = "closed"
-    client.tcp_handle:close()
+    if not client.tcp_handle:is_closing() then
+      client.tcp_handle:close()
+    end
   end
 
   client.state = "closing"


### PR DESCRIPTION
## Problem
When a connection is interrupted during an async write, the callback at client.lua:219 can attempt to close a handle that's already closing, causing:
```
handle 0x... is already closing
```

## Root Cause
`tcp.lua:161-162` correctly guards with `is_closing()`:
```lua
if not client.tcp_handle:is_closing() then
  client.tcp_handle:close()
end
```

But `client.lua:219,223` doesn't use this guard.

## Fix
Add the same `is_closing()` check to `client.lua` to match the existing pattern.

## Testing
- Reproduced error by rapidly toggling Claude Code connection
- Error no longer occurs after fix