### PR TITLE
fix: skip selection tracking in terminal mode to prevent flicker

### DIFF
--- a/lua/claudecode/selection.lua
+++ b/lua/claudecode/selection.lua
@@ -88,6 +88,10 @@ end
 ---Handles cursor movement events.
 ---Triggers a debounced update of the selection.
 function M.on_cursor_moved()
+  local current_mode = vim.fn.mode()
+  if current_mode == "t" then
+    return
+  end
   M.debounce_update()
 end
 


### PR DESCRIPTION
When moving cursor in Claude Code's interactive terminal UI, each cursor movement was triggering selection update API calls that caused screen flickering. This fix checks the current mode and skips selection tracking when in terminal mode ('t').