### PR TITLE
fix: claudecode terminal listed in buffer issue

### DIFF
--- a/lua/claudecode/terminal/native.lua
+++ b/lua/claudecode/terminal/native.lua
@@ -132,6 +132,7 @@ local function open_terminal(cmd_string, env_table, effective_config, focus)
   winid = new_winid
   bufnr = vim.api.nvim_get_current_buf()
   vim.bo[bufnr].bufhidden = "hide"
+  vim.bo[bufnr].buflisted = false
   -- buftype=terminal is set by termopen
 
   if focus then


### PR DESCRIPTION
Set `buflisted` as false, to ensure hide claudecode.nvim's terminal in buffer list.
without this, editing window can switched to cc's  terminal buffer accidentally.

Like this. (inially opened cc term to right side, and edit widow in left side switched to terminal buf, mistakenly.

<img width="2229" height="507" alt="image" src="https://github.com/user-attachments/assets/9b46aeca-8b82-4d0a-a30c-874d3f7be28f" />

This PR is prevent this behavior.