### PR TITLE
fix(diff): close plugin-created split on cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,22 +288,27 @@ require("claudecode").setup({
 
 The `diff_opts` configuration allows you to customize diff behavior:
 
+- `layout` ("vertical"|"horizontal", default: `"vertical"`) - Whether the diff panes open in a vertical or horizontal split.
 - `keep_terminal_focus` (boolean, default: `false`) - When enabled, keeps focus in the Claude Code terminal when a diff opens instead of moving focus to the diff buffer. This allows you to continue using terminal keybindings like `<CR>` for accepting/rejecting diffs without accidentally triggering other mappings.
 - `open_in_new_tab` (boolean, default: `false`) - Open diffs in a new tab instead of the current tab.
 - `hide_terminal_in_new_tab` (boolean, default: `false`) - When opening diffs in a new tab, do not show the Claude terminal split in that new tab. The terminal remains in the original tab, giving maximum screen estate for reviewing the diff.
+- `on_new_file_reject` ("keep_empty"|"close_window", default: `"keep_empty"`) - Behavior when rejecting a diff for a new file (where the old file did not exist).
+- Legacy aliases (still supported): `vertical_split` (maps to `layout`) and `open_in_current_tab` (inverse of `open_in_new_tab`).
 
 **Example use case**: If you frequently use `<CR>` or arrow keys in the Claude Code terminal to accept/reject diffs, enable this option to prevent focus from moving to the diff buffer where `<CR>` might trigger unintended actions.
 
 ```lua
 require("claudecode").setup({
   diff_opts = {
-    keep_terminal_focus = true,  -- If true, moves focus back to terminal after diff opens
-    open_in_new_tab = true,      -- Open diff in a separate tab
+    layout = "vertical", -- "vertical" or "horizontal"
+    keep_terminal_focus = true, -- If true, moves focus back to terminal after diff opens
+    open_in_new_tab = true, -- Open diff in a separate tab
     hide_terminal_in_new_tab = true, -- In the new tab, do not show Claude terminal
-    auto_close_on_accept = true,
-    show_diff_stats = true,
-    vertical_split = true,
-    open_in_current_tab = true,
+    on_new_file_reject = "keep_empty", -- "keep_empty" or "close_window"
+
+    -- Legacy aliases (still supported):
+    -- vertical_split = true,
+    -- open_in_current_tab = true,
   },
 })
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -153,6 +153,9 @@ vv netrw      # Start Neovim with built-in netrw configuration
 
 # List available configurations
 list-configs
+
+# Minimal repro environment (copies fixtures/repro/example into /tmp)
+repro
 ```
 
 **Example fixture structure** (`fixtures/my-integration/`):

--- a/README.md
+++ b/README.md
@@ -277,10 +277,15 @@ For deep technical details, see [ARCHITECTURE.md](./ARCHITECTURE.md).
 
     -- Diff Integration
     diff_opts = {
-      auto_close_on_accept = true,
-      vertical_split = true,
-      open_in_current_tab = true,
-      keep_terminal_focus = false, -- If true, moves focus back to terminal after diff opens (including floating terminals)
+      layout = "vertical", -- "vertical" or "horizontal"
+      open_in_new_tab = false,
+      keep_terminal_focus = false, -- If true, moves focus back to terminal after diff opens
+      hide_terminal_in_new_tab = false,
+      -- on_new_file_reject = "keep_empty", -- "keep_empty" or "close_window"
+
+      -- Legacy aliases (still supported):
+      -- vertical_split = true,
+      -- open_in_current_tab = true,
     },
   },
   keys = {

--- a/fixtures/bin/repro
+++ b/fixtures/bin/repro
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# repro - Launch Neovim with the minimal "repro" fixture + a temp workspace.
+#
+# This is intended to provide a low-noise environment for reproducing issues in claudecode.nvim.
+
+FIXTURES_DIR="$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)"
+
+# Source common functions
+source "$FIXTURES_DIR/bin/common.sh"
+
+config="repro"
+if ! validate_config "$FIXTURES_DIR" "$config"; then
+  exit 1
+fi
+
+template_dir="$FIXTURES_DIR/$config/example"
+if [[ ! -d "$template_dir" ]]; then
+  echo "Error: repro template directory not found: $template_dir" >&2
+  exit 1
+fi
+
+workspace_dir="${TMPDIR:-/tmp}/claudecode.nvim-repro"
+
+# Safety check before deleting
+if [[ -z "$workspace_dir" || "$workspace_dir" == "/" ]]; then
+  echo "Error: unsafe workspace_dir: '$workspace_dir'" >&2
+  exit 1
+fi
+
+rm -rf "$workspace_dir"
+mkdir -p "$workspace_dir"
+cp -R "$template_dir/." "$workspace_dir/"
+
+echo "Repro workspace: $workspace_dir"
+echo "Repro config: $FIXTURES_DIR/$config"
+echo "Tip: run 'vve repro' to edit the config or open $template_dir/README.md for steps."
+
+# If no args are provided, open the default file to keep the window non-empty.
+if [[ $# -eq 0 ]]; then
+  nvim_args=("a.txt")
+else
+  nvim_args=("$@")
+fi
+
+(cd "$workspace_dir" && NVIM_APPNAME="$config" XDG_CONFIG_HOME="$FIXTURES_DIR" nvim "${nvim_args[@]}")

--- a/fixtures/bin/repro
+++ b/fixtures/bin/repro
@@ -16,6 +16,45 @@ if ! validate_config "$FIXTURES_DIR" "$config"; then
   exit 1
 fi
 
+keep_workspace=false
+
+# Parse repro-specific flags.
+# Everything else is passed to nvim.
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keep|--no-reset)
+      keep_workspace=true
+      shift
+      ;;
+    --help|-h)
+      cat <<'EOF'
+repro - Launch Neovim with the minimal "repro" fixture + a temp workspace.
+
+Usage:
+  repro [--keep] [nvim args...]
+
+Options:
+  --keep, --no-reset  Reuse the existing repro workspace instead of resetting it
+
+Examples:
+  repro
+  repro --keep
+  repro --headless "+qall!"
+EOF
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+nvim_args=("$@")
+
 template_dir="$FIXTURES_DIR/$config/example"
 if [[ ! -d "$template_dir" ]]; then
   echo "Error: repro template directory not found: $template_dir" >&2
@@ -30,19 +69,21 @@ if [[ -z "$workspace_dir" || "$workspace_dir" == "/" ]]; then
   exit 1
 fi
 
-rm -rf "$workspace_dir"
-mkdir -p "$workspace_dir"
-cp -R "$template_dir/." "$workspace_dir/"
+if [[ "$keep_workspace" == "true" && -d "$workspace_dir" ]]; then
+  echo "Repro workspace (kept): $workspace_dir"
+else
+  rm -rf "$workspace_dir"
+  mkdir -p "$workspace_dir"
+  cp -R "$template_dir/." "$workspace_dir/"
+  echo "Repro workspace (reset): $workspace_dir"
+fi
 
-echo "Repro workspace: $workspace_dir"
 echo "Repro config: $FIXTURES_DIR/$config"
-echo "Tip: run 'vve repro' to edit the config or open $template_dir/README.md for steps."
+echo "Tip: :e README.md in the repro workspace for steps."
 
 # If no args are provided, open the default file to keep the window non-empty.
-if [[ $# -eq 0 ]]; then
+if [[ ${#nvim_args[@]} -eq 0 ]]; then
   nvim_args=("a.txt")
-else
-  nvim_args=("$@")
 fi
 
 (cd "$workspace_dir" && NVIM_APPNAME="$config" XDG_CONFIG_HOME="$FIXTURES_DIR" nvim "${nvim_args[@]}")

--- a/fixtures/nvim-aliases.sh
+++ b/fixtures/nvim-aliases.sh
@@ -14,7 +14,10 @@ alias vv="$BIN_DIR/vv"
 alias vve="$BIN_DIR/vve"
 # shellcheck disable=SC2139
 alias list-configs="$BIN_DIR/list-configs"
+# shellcheck disable=SC2139
+alias repro="$BIN_DIR/repro"
 
 echo "Neovim configuration aliases loaded!"
 echo "Use 'vv <config>' or 'vve <config>' to test configurations"
+echo "Use 'repro' for a minimal claudecode.nvim repro environment"
 echo "Use 'list-configs' to see available options"

--- a/fixtures/repro/example/README.md
+++ b/fixtures/repro/example/README.md
@@ -1,0 +1,58 @@
+# claudecode.nvim repro workspace
+
+This directory is copied into a temp workspace when you run `repro`.
+
+## Quick start
+
+From the repo root:
+
+```sh
+source fixtures/nvim-aliases.sh
+repro
+```
+
+That will:
+
+- create `/tmp/claudecode.nvim-repro` (reset on every run)
+- open Neovim with the **minimal** `fixtures/repro` config
+- open `a.txt` so your current window is non-empty
+
+## Reproducing issue #155 (leftover diff split)
+
+Goal: confirm that after accepting a diff for a file that was *not* already open, we do **not** leave behind an extra split.
+
+1. In Neovim, note window count:
+
+   ```vim
+   :echo winnr('$')
+   ```
+
+2. Start Claude:
+
+   ```vim
+   :ClaudeCode
+   ```
+
+3. In the Claude terminal, ask Claude to make a small edit to `b.txt`.
+
+   **Important:** Do *not* open `b.txt` in a Neovim window yourself before the diff opens.
+
+4. When the diff opens, accept it:
+
+   - `:w` from the proposed buffer **or**
+   - `<leader>aa`
+
+5. Wait for Claude to close the diff (the plugin cleans up when Claude calls `close_tab`).
+
+6. Confirm window count returned to what it was in step 1:
+
+   ```vim
+   :echo winnr('$')
+   ```
+
+You should not see an orphaned split after accept.
+
+## Notes
+
+- This fixture uses the **native** terminal provider to avoid depending on external plugins.
+- To tweak the config, edit `fixtures/repro/init.lua` (or run `vve repro`).

--- a/fixtures/repro/example/README.md
+++ b/fixtures/repro/example/README.md
@@ -13,44 +13,42 @@ repro
 
 That will:
 
-- create `/tmp/claudecode.nvim-repro` (reset on every run)
+- create `/tmp/claudecode.nvim-repro` (reset on every run; use `repro --keep` to reuse)
 - open Neovim with the **minimal** `fixtures/repro` config
 - open `a.txt` so your current window is non-empty
 
-## Reproducing issue #155 (leftover diff split)
+## Iterating on the config
 
-Goal: confirm that after accepting a diff for a file that was *not* already open, we do **not** leave behind an extra split.
+The Neovim config lives at `fixtures/repro/init.lua`.
 
-1. In Neovim, note window count:
+- Edit it from another terminal:
 
-   ```vim
-   :echo winnr('$')
-   ```
+  ```sh
+  vve repro
+  ```
 
-2. Start Claude:
+  Then restart the running `repro` Neovim instance to pick up changes.
 
-   ```vim
-   :ClaudeCode
-   ```
+- Or edit it from inside the running `repro` session:
 
-3. In the Claude terminal, ask Claude to make a small edit to `b.txt`.
+  ```vim
+  :ReproEditConfig
+  ```
 
-   **Important:** Do *not* open `b.txt` in a Neovim window yourself before the diff opens.
+> Note: config changes generally require restarting Neovim (this fixture avoids a plugin manager / hot-reload).
 
-4. When the diff opens, accept it:
+## Example flow (sanity check)
 
-   - `:w` from the proposed buffer **or**
-   - `<leader>aa`
+A basic end-to-end diff flow you can use to sanity-check the environment:
 
-5. Wait for Claude to close the diff (the plugin cleans up when Claude calls `close_tab`).
+1. Start Claude:
 
-6. Confirm window count returned to what it was in step 1:
+   - press `<leader>ac` (starts the server if needed, then opens the terminal), **or**
+   - run `:ClaudeCodeStart` then `:ClaudeCode`
 
-   ```vim
-   :echo winnr('$')
-   ```
-
-You should not see an orphaned split after accept.
+2. Ask Claude to edit `b.txt` (do not open it in a window first)
+3. Accept the diff with `:w` (or `<leader>aa`)
+4. Confirm you didn’t get any extra leftover windows: `:echo winnr('$')`
 
 ## Notes
 

--- a/fixtures/repro/example/a.txt
+++ b/fixtures/repro/example/a.txt
@@ -1,0 +1,4 @@
+This is file A.
+
+Keep this file open.
+Ask Claude to edit b.txt (without opening b.txt in a window first).

--- a/fixtures/repro/example/b.txt
+++ b/fixtures/repro/example/b.txt
@@ -1,0 +1,2 @@
+line1
+line2

--- a/fixtures/repro/init.lua
+++ b/fixtures/repro/init.lua
@@ -1,0 +1,47 @@
+-- Minimal repro config for claudecode.nvim issues.
+--
+-- This fixture intentionally avoids a plugin manager so it's easy to run and reason about.
+--
+-- Usage (from repo root):
+--   source fixtures/nvim-aliases.sh
+--   repro
+--
+-- To edit this config:
+--   vve repro
+
+-- Ensure this repo is on the runtimepath so `plugin/claudecode.lua` is loaded.
+local config_dir = vim.fn.stdpath("config")
+local repo_root = vim.fn.fnamemodify(config_dir, ":h:h")
+
+vim.opt.rtp:prepend(repo_root)
+
+-- Basic editor settings
+vim.g.mapleader = " "
+vim.g.maplocalleader = "\\"
+
+local ok, claudecode = pcall(require, "claudecode")
+assert(ok, "Failed to load claudecode.nvim from repo root: " .. tostring(claudecode))
+
+claudecode.setup({
+  log_level = "debug",
+  terminal = {
+    provider = "native",
+    auto_close = false,
+  },
+  diff_opts = {
+    layout = "vertical",
+    open_in_new_tab = false,
+    keep_terminal_focus = false,
+  },
+})
+
+-- Keymaps (kept small on purpose)
+vim.keymap.set("n", "<leader>ac", "<cmd>ClaudeCode<cr>", { desc = "Toggle Claude" })
+vim.keymap.set("n", "<leader>af", "<cmd>ClaudeCodeFocus<cr>", { desc = "Focus Claude" })
+
+vim.keymap.set("n", "<leader>aa", "<cmd>ClaudeCodeDiffAccept<cr>", { desc = "Accept diff" })
+vim.keymap.set("n", "<leader>ad", "<cmd>ClaudeCodeDiffDeny<cr>", { desc = "Deny diff" })
+
+vim.keymap.set("n", "<leader>aw", function()
+  vim.notify(("windows in tab: %d"):format(vim.fn.winnr("$")))
+end, { desc = "Claude: show window count" })

--- a/fixtures/repro/init.lua
+++ b/fixtures/repro/init.lua
@@ -78,7 +78,6 @@ end, { desc = "Focus Claude" })
 vim.keymap.set("n", "<leader>aa", "<cmd>ClaudeCodeDiffAccept<cr>", { desc = "Accept diff" })
 vim.keymap.set("n", "<leader>ad", "<cmd>ClaudeCodeDiffDeny<cr>", { desc = "Deny diff" })
 
-
 -- Convenience helpers for iterating on this fixture.
 vim.api.nvim_create_user_command("ReproEditConfig", function()
   local config_path = vim.fn.stdpath("config") .. "/init.lua"

--- a/fixtures/repro/init.lua
+++ b/fixtures/repro/init.lua
@@ -63,13 +63,15 @@ end
 -- Keymaps (kept small on purpose)
 vim.keymap.set("n", "<leader>ac", function()
   if ensure_claudecode_started() then
-    vim.cmd("ClaudeCode")
+    local terminal = require("claudecode.terminal")
+    terminal.simple_toggle({}, nil)
   end
 end, { desc = "Toggle Claude" })
 
 vim.keymap.set("n", "<leader>af", function()
   if ensure_claudecode_started() then
-    vim.cmd("ClaudeCodeFocus")
+    local terminal = require("claudecode.terminal")
+    terminal.focus_toggle({}, nil)
   end
 end, { desc = "Focus Claude" })
 
@@ -80,7 +82,12 @@ vim.keymap.set("n", "<leader>ad", "<cmd>ClaudeCodeDiffDeny<cr>", { desc = "Deny 
 -- Convenience helpers for iterating on this fixture.
 vim.api.nvim_create_user_command("ReproEditConfig", function()
   local config_path = vim.fn.stdpath("config") .. "/init.lua"
-  vim.cmd("edit " .. vim.fn.fnameescape(config_path))
+
+  -- Open the config file without `:edit` / `vim.cmd(...)` so we don't trigger
+  -- Treesitter "vim" language injections (which can be noisy if parsers/queries mismatch).
+  local bufnr = vim.fn.bufadd(config_path)
+  vim.fn.bufload(bufnr)
+  vim.api.nvim_set_current_buf(bufnr)
 end, { desc = "Edit the repro Neovim config" })
 
 vim.keymap.set("n", "<leader>ae", "<cmd>ReproEditConfig<cr>", { desc = "Edit repro config" })

--- a/tests/unit/diff_split_window_cleanup_spec.lua
+++ b/tests/unit/diff_split_window_cleanup_spec.lua
@@ -1,0 +1,130 @@
+require("tests.busted_setup")
+
+local function reset_vim_state_for_splits()
+  assert(vim and vim._mock and vim._mock.reset, "Expected vim mock with _mock.reset()")
+
+  vim._mock.reset()
+
+  -- Recreate a minimal tab/window state suitable for split operations.
+  vim._tabs = { [1] = true }
+  vim._current_tabpage = 1
+  vim._current_window = 1000
+  vim._next_winid = 1001
+
+  vim._mock.add_buffer(1, "/home/user/project/test.lua", "local test = {}\nreturn test", { modified = false })
+  vim._mock.add_window(1000, 1, { 1, 0 })
+  vim._win_tab[1000] = 1
+  vim._tab_windows[1] = { 1000 }
+end
+
+describe("Diff split window cleanup", function()
+  local diff
+  local test_old_file = "/tmp/test_split_window_cleanup_old.txt"
+  local tab_name = "test_split_window_cleanup_tab"
+
+  before_each(function()
+    reset_vim_state_for_splits()
+
+    -- Prepare a dummy file
+    local f = assert(io.open(test_old_file, "w"))
+    f:write("line1\nline2\n")
+    f:close()
+
+    -- Minimal logger stub
+    package.loaded["claudecode.logger"] = {
+      debug = function() end,
+      error = function() end,
+      info = function() end,
+      warn = function() end,
+    }
+
+    -- Reload diff module cleanly
+    package.loaded["claudecode.diff"] = nil
+    diff = require("claudecode.diff")
+
+    diff.setup({
+      diff_opts = {
+        layout = "vertical",
+        open_in_new_tab = false,
+        keep_terminal_focus = false,
+      },
+      terminal = {},
+    })
+  end)
+
+  after_each(function()
+    os.remove(test_old_file)
+    if diff and diff._cleanup_all_active_diffs then
+      diff._cleanup_all_active_diffs("test teardown")
+    end
+    package.loaded["claudecode.diff"] = nil
+  end)
+
+  it("closes the plugin-created original split after accept when close_tab is invoked", function()
+    local params = {
+      old_file_path = test_old_file,
+      new_file_path = test_old_file,
+      new_file_contents = "new1\nnew2\n",
+      tab_name = tab_name,
+    }
+
+    diff._setup_blocking_diff(params, function() end)
+
+    local state = diff._get_active_diffs()[tab_name]
+    assert.is_table(state)
+
+    local new_win = state.new_window
+    local target_win = state.target_window
+
+    -- Should have created an extra split for the original side (target_win != 1000)
+    assert.are_not.equal(1000, target_win)
+    assert.is_true(vim.api.nvim_win_is_valid(target_win))
+    assert.is_true(vim.api.nvim_win_is_valid(new_win))
+
+    diff._resolve_diff_as_saved(tab_name, state.new_buffer)
+
+    -- Accept should not close windows yet
+    assert.is_true(vim.api.nvim_win_is_valid(target_win))
+
+    local closed = diff.close_diff_by_tab_name(tab_name)
+    assert.is_true(closed)
+
+    assert.is_false(vim.api.nvim_win_is_valid(new_win))
+    assert.is_false(vim.api.nvim_win_is_valid(target_win))
+    assert.is_true(vim.api.nvim_win_is_valid(1000))
+  end)
+
+  it("does not close the reused target window when the old file is already open", function()
+    -- Open the old file in the main window so choose_original_window reuses it
+    vim.cmd("edit " .. vim.fn.fnameescape(test_old_file))
+
+    local params = {
+      old_file_path = test_old_file,
+      new_file_path = test_old_file,
+      new_file_contents = "new content\n",
+      tab_name = tab_name,
+    }
+
+    diff._setup_blocking_diff(params, function() end)
+
+    local state = diff._get_active_diffs()[tab_name]
+    assert.is_table(state)
+
+    local new_win = state.new_window
+    local target_win = state.target_window
+
+    assert.are.equal(1000, target_win)
+    assert.is_true(vim.api.nvim_win_is_valid(new_win))
+
+    diff._resolve_diff_as_saved(tab_name, state.new_buffer)
+
+    local closed = diff.close_diff_by_tab_name(tab_name)
+    assert.is_true(closed)
+
+    assert.is_false(vim.api.nvim_win_is_valid(new_win))
+    assert.is_true(vim.api.nvim_win_is_valid(1000))
+
+    -- In reuse scenario, diff mode should have been disabled.
+    assert.are.equal("diffoff", vim._last_command)
+  end)
+end)


### PR DESCRIPTION
Fixes #155.

This PR prevents leftover diff splits by tracking which windows are created by the diff UI and cleaning them up deterministically when `close_tab` is invoked.

### Summary
- Track when the original-side window was created via an automatic split, and close it during cleanup.
- When `open_diff_blocking()` is called with an existing `tab_name`, resolve/cleanup the prior diff state to avoid leaked windows.
- Add unit tests for both the split-created and reuse-existing-window cases.
- Update docs to prefer modern `diff_opts` keys and clarify legacy aliases.

### Testing
- `make check` / `make test` could not be run in this environment because `luacheck` / `busted` are not installed.
- Lua syntax checks were run for `lua/` and `tests/`.

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Fix issue #155 (diff splits left behind)

## Context / Why
Issue **coder/claudecode.nvim#155** reports that during Claude-driven edits the plugin frequently opens a 2-pane diff (original + proposed) as vertical splits, but **after accepting** the change **one split remains**. Over time, repeated diffs accumulate these leftover windows, forcing users to manually `:q` them.

Goal: make diff UI cleanup deterministic so that, when a diff is closed (via the `close_tab` MCP tool), the plugin **closes any windows it created for the diff** and does not leak extra splits.

## Evidence (what I inspected)
- Issue text + comments via GitHub API (6 comments). Key repro note: when the file is *not already open*, the plugin opens it in a new split and then splits again for the diff; on accept it returns to the extra split (comment by `ehaynes99`, 2025-11-14).
- `lua/claudecode/diff.lua`
  - Window creation: `_create_diff_view_from_window()` calls `choose_original_window(...)` and, when `decision == "split"`, runs `create_split()` and uses that new window for the original side (around lines ~933–941).
  - Cleanup: `_cleanup_diff_state()` closes `diff_data.new_window` but only runs `:diffoff` in `diff_data.target_window` (around lines ~1029–1039). If `target_window` was created by `create_split()`, it stays open.
  - Replacement: `open_diff_blocking()` calls `_resolve_diff_as_rejected()` when an active diff with the same `tab_name` already exists, but does not clean up its windows (around ~1262–1265).
- `lua/claudecode/config.lua`: legacy options `vertical_split` and `open_in_current_tab` are mapped onto modern `diff_opts.layout` and `diff_opts.open_in_new_tab` (lines ~205–215).
- Docs drift:
  - `README.md` still documents legacy keys like `vertical_split` / `open_in_current_tab` and mentions `auto_close_on_accept` (which is validated but not implemented).
  - `CLAUDE.md` documents `open_in_new_tab` but includes an example that also sets legacy keys, which overrides the new setting.

## Plan

### 1) Track which diff windows were created by the plugin
**Why:** cleanup must differentiate between windows that were part of the user’s pre-existing layout vs windows created solely to render the diff.

- Extend the diff layout/state structures to record window ownership:
  - Add `target_window_created_by_plugin: boolean` (or `original_window_created_by_plugin`) to the object returned by `_create_diff_view_from_window()`.
  - Persist the flag into `active_diffs[tab_name]` in `_setup_blocking_diff()`.
- Set the flag conservatively:
  - If `choose_original_window(...).decision == "split"`, then `target_window_created_by_plugin = true` because we just created `original_window` via `create_split()`.
  - Otherwise, `false` (reused an existing window).

<details>
<summary>Optional hardening (if you want to cover more layouts)</summary>

There is another window-creation path when `_create_diff_view_from_window()` is called with `target_window == nil` and it needs to `create_split()` away from a terminal/sidebar buffer (around ~908–927). If this path is contributing to “mystery splits”, consider tracking a small list like `created_windows = { ... }` instead of a single boolean, so cleanup can close *all* plugin-created windows deterministically.

</details>

### 2) Close the plugin-created original-side window during cleanup
- Update `_cleanup_diff_state(tab_name, reason)` (non-new-tab branch):
  - Keep existing behavior of closing `diff_data.new_window` (proposed side).
  - For `diff_data.target_window`:
    - If `diff_data.target_window_created_by_plugin == true` and the window is still valid, close it with `nvim_win_close(..., true)`.
    - Else, preserve current behavior (`vim.cmd("diffoff")`) so we don’t destroy a user’s pre-existing window.

**Safety:** only close windows we explicitly created.

### 3) Clean up when replacing an active diff with the same `tab_name`
**Why:** avoids accumulating stale diff windows/state when the CLI requests a new diff before the old one is fully closed.

- In `open_diff_blocking()`:
  - If `active_diffs[tab_name]` exists, call `_resolve_diff_as_rejected(tab_name)` *and then* `_cleanup_diff_state(tab_name, "replaced by new diff")` before starting the new diff.
  - This is safe because the `close_tab` tool already treats “diff not found” as success.

### 4) Add/extend unit tests to prevent regressions
Add a focused spec that reproduces issue #155 using the existing vim mock (which simulates `:vsplit` and window closing).

- **Test: closes plugin-created original window after accept**
  1. Create a real temp file (old file) and set current window to a different named buffer so `choose_original_window` must `split`.
  2. Call `diff._setup_blocking_diff(...)`.
  3. Capture `target_window` + `new_window` from `diff._get_active_diffs()[tab_name]`.
  4. Call `diff._resolve_diff_as_saved(tab_name, new_buffer)` then `diff.close_diff_by_tab_name(tab_name)`.
  5. Assert both `new_window` and `target_window` are no longer valid, and the original user window is still valid.

- **Test: does not close reused existing window**
  - Set current window to already display the old file (or an empty unmodified buffer) so `decision == "reuse"`.
  - Ensure cleanup closes only `new_window`, and keeps the reused window alive.

### 5) Documentation cleanup (reduce user confusion)
- Update `README.md` diff section to document **modern keys**:
  - `diff_opts.layout = "vertical"|"horizontal"`
  - `diff_opts.open_in_new_tab`
  - `diff_opts.keep_terminal_focus`, `diff_opts.hide_terminal_in_new_tab`, `diff_opts.on_new_file_reject`
  - Mark `vertical_split` / `open_in_current_tab` as **legacy aliases** (or remove them from examples).
- Fix `CLAUDE.md` example so it doesn’t set both `open_in_new_tab` and legacy `open_in_current_tab` at the same time.
- Either remove or explicitly label `auto_close_on_accept` / `show_diff_stats` as legacy/no-op until implemented.

## Acceptance Criteria
- Repro from issue #155 no longer leaves an extra split after accept (and likewise after reject for existing files).
- Repeated diffs do not accumulate leftover diff windows.
- Unit tests covering window ownership + cleanup pass (`make test`).
- Docs reflect the actual supported configuration knobs.

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.2` • Thinking: `xhigh`_
