### PR TITLE
fix(diff): keep terminal focus for floating terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ For deep technical details, see [ARCHITECTURE.md](./ARCHITECTURE.md).
       auto_close_on_accept = true,
       vertical_split = true,
       open_in_current_tab = true,
-      keep_terminal_focus = false, -- If true, moves focus back to terminal after diff opens
+      keep_terminal_focus = false, -- If true, moves focus back to terminal after diff opens (including floating terminals)
     },
   },
   keys = {

--- a/lua/claudecode/config.lua
+++ b/lua/claudecode/config.lua
@@ -23,7 +23,7 @@ M.defaults = {
   diff_opts = {
     layout = "vertical",
     open_in_new_tab = false, -- Open diff in a new tab (false = use current tab)
-    keep_terminal_focus = false, -- If true, moves focus back to terminal after diff opens
+    keep_terminal_focus = false, -- If true, moves focus back to terminal after diff opens (including floating terminals)
     hide_terminal_in_new_tab = false, -- If true and opening in a new tab, do not show Claude terminal there
     on_new_file_reject = "keep_empty", -- "keep_empty" leaves an empty buffer; "close_window" closes the placeholder split
   },

--- a/tests/unit/diff_keep_terminal_focus_float_spec.lua
+++ b/tests/unit/diff_keep_terminal_focus_float_spec.lua
@@ -1,0 +1,112 @@
+require("tests.busted_setup")
+
+-- Regression test for #150:
+-- When diff_opts.keep_terminal_focus = true and the Claude terminal lives in a floating window,
+-- opening a diff should return focus to the floating terminal (not the diff split behind it).
+
+describe("Diff keep_terminal_focus with floating terminal", function()
+  local diff
+
+  local test_old_file = "/tmp/claudecode_keep_focus_old.txt"
+  local test_new_file = "/tmp/claudecode_keep_focus_new.txt"
+  local tab_name = "keep-focus-float"
+
+  local editor_win = 1000
+  local terminal_win = 1001
+  local terminal_buf
+
+  before_each(function()
+    -- Fresh vim mock state
+    if vim and vim._mock and vim._mock.reset then
+      vim._mock.reset()
+    end
+
+    -- Ensure predictable tab/window state
+    vim._tabs = { [1] = true }
+    vim._current_tabpage = 1
+
+    -- Reload diff module cleanly
+    package.loaded["claudecode.diff"] = nil
+    diff = require("claudecode.diff")
+
+    -- Create a normal, non-floating editor window
+    local editor_buf = vim.api.nvim_create_buf(true, false)
+    vim._windows[editor_win] = { buf = editor_buf, width = 80 }
+    vim._win_tab[editor_win] = 1
+
+    -- Create a floating window for the terminal
+    terminal_buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_option(terminal_buf, "buftype", "terminal")
+    vim._windows[terminal_win] = {
+      buf = terminal_buf,
+      width = 80,
+      config = { relative = "editor" },
+    }
+    vim._win_tab[terminal_win] = 1
+
+    vim._tab_windows[1] = { editor_win, terminal_win }
+    vim._current_window = terminal_win
+    vim._next_winid = 1002
+
+    -- Provide minimal config directly to diff module
+    diff.setup({
+      terminal = { split_side = "right", split_width_percentage = 0.30 },
+      diff_opts = {
+        layout = "vertical",
+        open_in_new_tab = false,
+        keep_terminal_focus = true,
+      },
+    })
+
+    -- Stub terminal provider with a valid terminal buffer
+    package.loaded["claudecode.terminal"] = {
+      get_active_terminal_bufnr = function()
+        return terminal_buf
+      end,
+      ensure_visible = function() end,
+    }
+
+    -- Create a real file so filereadable() returns 1 in mocks
+    local f = io.open(test_old_file, "w")
+    f:write("line1\nline2\n")
+    f:close()
+
+    -- Ensure a clean diff state
+    diff._cleanup_all_active_diffs("test_setup")
+  end)
+
+  after_each(function()
+    os.remove(test_old_file)
+    os.remove(test_new_file)
+
+    package.loaded["claudecode.terminal"] = nil
+
+    if diff then
+      diff._cleanup_all_active_diffs("test_teardown")
+    end
+  end)
+
+  it("restores focus to floating terminal window after diff opens", function()
+    local co = coroutine.create(function()
+      diff.open_diff_blocking(test_old_file, test_new_file, "updated content\n", tab_name)
+    end)
+
+    local ok, err = coroutine.resume(co)
+    assert.is_true(ok, tostring(err))
+    assert.equal("suspended", coroutine.status(co))
+
+    -- keep_terminal_focus uses vim.schedule; the vim mock executes scheduled callbacks immediately.
+
+    -- Floating terminals (e.g. Snacks) should manage their own sizing.
+    assert.equal(80, vim.api.nvim_win_get_width(terminal_win))
+    assert.equal(terminal_win, vim.api.nvim_get_current_win())
+
+    -- Resolve to finish the coroutine
+    vim.schedule(function()
+      diff._resolve_diff_as_rejected(tab_name)
+    end)
+    vim.wait(100, function()
+      return coroutine.status(co) == "dead"
+    end)
+  end)
+end)


### PR DESCRIPTION
Fixes #150.

When `diff_opts.keep_terminal_focus = true` and the Claude terminal is a floating window (e.g. Snacks `position="float"`), opening a diff no longer steals focus to the hidden diff split.

### Changes
- Allow `find_claudecode_terminal_window()` to fall back to floating windows (still preferring split terminals)
- Avoid resizing floating terminals when restoring terminal widths
- Add a unit regression test for floating-terminal focus

### Tests
- `make check`
- `make test`

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Investigate + fix #150 (keep_terminal_focus skips floating terminal windows)

## Context / Why
Issue #150 reports that when `diff_opts.keep_terminal_focus = true` and the Claude terminal is displayed as a *floating* window (e.g. via Snacks `snacks_win_opts = { position = "float" }`), opening a diff steals focus to the diff split **behind** the float. Because focus never returns to the terminal, user input goes to the hidden diff window and the UX breaks.

Goal: confirm whether this is a bug (vs expected behavior) and, if so, outline a safe fix + regression coverage.

## Evidence (what was verified)
- GitHub issue #150 text explicitly points to `find_claudecode_terminal_window()` in `lua/claudecode/diff.lua` as skipping floats.
- `lua/claudecode/diff.lua`:
  - `find_claudecode_terminal_window()` currently returns the terminal window **only if it is not floating** (checks `win_config.relative`).
  - `setup_new_buffer()` uses this helper under `diff_opts.keep_terminal_focus` to restore focus after opening a diff.
- Config intent: `lua/claudecode/config.lua` documents `diff_opts.keep_terminal_focus` as “moves focus back to terminal after diff opens”, with no caveat about floating windows.

## Bug assessment
**Confirmed bug.**

With `keep_terminal_focus = true`, the plugin intends to refocus the Claude terminal after creating the diff window. When the terminal lives in a floating window, `find_claudecode_terminal_window()` returns `nil`, so the scheduled refocus never happens. This matches the issue report and is inconsistent with the documented meaning of `keep_terminal_focus`.

## Implementation plan (fix + prove)

### 1) Add a regression test that fails on current `main`
Add a unit test that simulates a floating terminal window:
- Test location: add to an existing diff blocking spec (e.g. `tests/unit/diff_mcp_spec.lua`) or create a focused new spec (e.g. `tests/unit/diff_keep_terminal_focus_float_spec.lua`).
- Arrange:
  - `diff.setup({ diff_opts = { keep_terminal_focus = true } })`.
  - Stub `package.loaded["claudecode.terminal"] = { get_active_terminal_bufnr = function() return TERM_BUF end }`.
  - Create a terminal buffer in the vim mock (`vim.api.nvim_create_buf`) and a *floating* window entry for it by setting `vim._windows[TERM_WIN].config = { relative = "editor" }` and ensuring `TERM_WIN` is in `vim._tab_windows[current_tab]`.
- Act: call `diff.open_diff_blocking(...)` inside a coroutine and `coroutine.resume` once (it should suspend after setup).
- Assert: after the first `resume`, `vim.api.nvim_get_current_win()` (or `vim._current_window`) should equal `TERM_WIN`.
  - This fails today because the float is filtered out.

Optional: add a second assertion for the non-floating case to ensure we don’t regress existing behavior.

### 2) Fix `find_claudecode_terminal_window()` to support floats
In `lua/claudecode/diff.lua`, update the helper so that it can return floating windows:
- Preferred behavior:
  - If multiple windows show the terminal buffer, prefer a non-floating window.
  - Otherwise, fall back to the floating window.

This preserves the original intent (prefer split terminals) while making `keep_terminal_focus` work for floats.

<details>
<summary>Fix sketch (for the implementer)</summary>

- Iterate windows; when `buf == terminal_bufnr`:
  - If `win_config.relative` is empty/nil → return immediately.
  - Else store as `floating_fallback`.
- After loop: return `floating_fallback`.

</details>

### 3) Ensure terminal-resize code remains sane for floats
`find_claudecode_terminal_window()` is also used in diff cleanup and terminal width restoration paths.
- Decide whether resizing should apply to floats:
  - If *yes*: do nothing special (current width logic is “percentage of columns” and is valid for floats too).
  - If *no*: gate `nvim_win_set_width` calls behind `win_config.relative == ""`.

Whichever behavior is chosen, add/adjust a test so the behavior is explicit.

### 4) Validate locally
- Run: `make test`, `make check`.
- Manual sanity check:
  - Configure Snacks terminal as float and `diff_opts.keep_terminal_focus = true`.
  - Trigger a diff (via Claude suggestion / openDiff tool).
  - Confirm focus stays/returns to the float terminal and typing goes to the terminal, not the hidden diff.

### 5) Close the loop on the issue
- Add a short note to docs/README or config docs clarifying that `keep_terminal_focus` supports both split and floating terminal windows.
- Reference issue #150 in the changelog/commit message (if the project maintains one).

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.2` • Thinking: `xhigh`_
