### PR TITLE
feat(diff): add option to minimize empty left pane for new files

### DIFF
--- a/lua/claudecode/config.lua
+++ b/lua/claudecode/config.lua
@@ -26,6 +26,7 @@ M.defaults = {
     keep_terminal_focus = false, -- If true, moves focus back to terminal after diff opens (including floating terminals)
     hide_terminal_in_new_tab = false, -- If true and opening in a new tab, do not show Claude terminal there
     on_new_file_reject = "keep_empty", -- "keep_empty" leaves an empty buffer; "close_window" closes the placeholder split
+    minimize_empty_diff_pane = false, -- If true, minimize the empty left pane width for new files (keeps diff highlighting)
   },
   models = {
     { name = "Claude Opus 4.1 (Latest)", value = "opus" },
@@ -139,6 +140,12 @@ function M.validate(config)
           config.diff_opts.on_new_file_reject == "keep_empty" or config.diff_opts.on_new_file_reject == "close_window"
         ),
       "diff_opts.on_new_file_reject must be 'keep_empty' or 'close_window'"
+    )
+  end
+  if config.diff_opts.minimize_empty_diff_pane ~= nil then
+    assert(
+      type(config.diff_opts.minimize_empty_diff_pane) == "boolean",
+      "diff_opts.minimize_empty_diff_pane must be a boolean"
     )
   end
 

--- a/lua/claudecode/diff.lua
+++ b/lua/claudecode/diff.lua
@@ -1217,6 +1217,14 @@ function M._setup_blocking_diff(params, resolution_callback)
       existing_buffer
     )
 
+    -- Minimize left pane width for new files if option enabled
+    if is_new_file and config and config.diff_opts and config.diff_opts.minimize_empty_diff_pane then
+      if diff_info.target_window and vim.api.nvim_win_is_valid(diff_info.target_window) then
+        local min_width = 8 -- Minimal width to show line numbers and diff signs
+        vim.api.nvim_win_set_width(diff_info.target_window, min_width)
+      end
+    end
+
     local autocmd_ids = register_diff_autocmds(tab_name, new_buffer)
 
     local original_cursor_pos = nil


### PR DESCRIPTION
Add `minimize_empty_diff_pane` option to diff_opts that reduces the width of the empty left pane when diffing new files. This keeps diff highlighting while maximizing screen space for the actual proposed content.

The left pane is set to a minimal width of 8 columns (enough for line numbers and diff signs) when this option is enabled.