### PR TITLE
fix: respect --resume/--continue args when terminal already exists

### DIFF
--- a/lua/claudecode/terminal.lua
+++ b/lua/claudecode/terminal.lua
@@ -514,8 +514,9 @@ end
 function M.simple_toggle(opts_override, cmd_args)
   local effective_config = build_config(opts_override)
   local cmd_string, claude_env_table = get_claude_command_and_env(cmd_args)
+  local force_new = cmd_args ~= nil and cmd_args ~= ""
 
-  get_provider().simple_toggle(cmd_string, claude_env_table, effective_config)
+  get_provider().simple_toggle(cmd_string, claude_env_table, effective_config, force_new)
 end
 
 ---Smart focus toggle: switches to terminal if not focused, hides if currently focused.
@@ -524,8 +525,9 @@ end
 function M.focus_toggle(opts_override, cmd_args)
   local effective_config = build_config(opts_override)
   local cmd_string, claude_env_table = get_claude_command_and_env(cmd_args)
+  local force_new = cmd_args ~= nil and cmd_args ~= ""
 
-  get_provider().focus_toggle(cmd_string, claude_env_table, effective_config)
+  get_provider().focus_toggle(cmd_string, claude_env_table, effective_config, force_new)
 end
 
 ---Toggle open terminal without focus if not already visible, otherwise do nothing.

--- a/lua/claudecode/terminal/native.lua
+++ b/lua/claudecode/terminal/native.lua
@@ -322,10 +322,21 @@ end
 ---@param cmd_string string
 ---@param env_table table
 ---@param effective_config ClaudeCodeTerminalConfig
-function M.simple_toggle(cmd_string, env_table, effective_config)
+---@param force_new boolean? If true, close any existing terminal and open a new one with cmd_string
+function M.simple_toggle(cmd_string, env_table, effective_config, force_new)
   -- Check if we have a valid terminal buffer (process running)
   local has_buffer = bufnr and vim.api.nvim_buf_is_valid(bufnr)
   local is_visible = has_buffer and is_terminal_visible()
+
+  -- If args like --resume or --continue were passed, force a new session
+  if force_new and has_buffer then
+    logger.debug("terminal", "simple_toggle: force_new=true, closing existing terminal to start new session")
+    M.close()
+    if not open_terminal(cmd_string, env_table, effective_config) then
+      vim.notify("Failed to open Claude terminal using native fallback (simple_toggle force_new).", vim.log.levels.ERROR)
+    end
+    return
+  end
 
   if is_visible then
     -- Terminal is visible, hide it (but keep process running)
@@ -362,10 +373,21 @@ end
 ---@param cmd_string string
 ---@param env_table table
 ---@param effective_config ClaudeCodeTerminalConfig
-function M.focus_toggle(cmd_string, env_table, effective_config)
+---@param force_new boolean? If true, close any existing terminal and open a new one with cmd_string
+function M.focus_toggle(cmd_string, env_table, effective_config, force_new)
   -- Check if we have a valid terminal buffer (process running)
   local has_buffer = bufnr and vim.api.nvim_buf_is_valid(bufnr)
   local is_visible = has_buffer and is_terminal_visible()
+
+  -- If args like --resume or --continue were passed, force a new session
+  if force_new and has_buffer then
+    logger.debug("terminal", "focus_toggle: force_new=true, closing existing terminal to start new session")
+    M.close()
+    if not open_terminal(cmd_string, env_table, effective_config) then
+      vim.notify("Failed to open Claude terminal using native fallback (focus_toggle force_new).", vim.log.levels.ERROR)
+    end
+    return
+  end
 
   if has_buffer then
     -- Terminal process exists

--- a/lua/claudecode/terminal/snacks.lua
+++ b/lua/claudecode/terminal/snacks.lua
@@ -173,13 +173,22 @@ end
 ---@param cmd_string string
 ---@param env_table table
 ---@param config table
-function M.simple_toggle(cmd_string, env_table, config)
+---@param force_new boolean? If true, close any existing terminal and open a new one with cmd_string
+function M.simple_toggle(cmd_string, env_table, config, force_new)
   if not is_available() then
     vim.notify("Snacks.nvim terminal provider selected but Snacks.terminal not available.", vim.log.levels.ERROR)
     return
   end
 
   local logger = require("claudecode.logger")
+
+  -- If args like --resume or --continue were passed, force a new session
+  if force_new and terminal and terminal:buf_valid() then
+    logger.debug("terminal", "Simple toggle: force_new=true, closing existing terminal to start new session")
+    M.close()
+    M.open(cmd_string, env_table, config)
+    return
+  end
 
   -- Check if terminal exists and is visible
   if terminal and terminal:buf_valid() and terminal:win_valid() then
@@ -201,13 +210,22 @@ end
 ---@param cmd_string string
 ---@param env_table table
 ---@param config table
-function M.focus_toggle(cmd_string, env_table, config)
+---@param force_new boolean? If true, close any existing terminal and open a new one with cmd_string
+function M.focus_toggle(cmd_string, env_table, config, force_new)
   if not is_available() then
     vim.notify("Snacks.nvim terminal provider selected but Snacks.terminal not available.", vim.log.levels.ERROR)
     return
   end
 
   local logger = require("claudecode.logger")
+
+  -- If args like --resume or --continue were passed, force a new session
+  if force_new and terminal and terminal:buf_valid() then
+    logger.debug("terminal", "Focus toggle: force_new=true, closing existing terminal to start new session")
+    M.close()
+    M.open(cmd_string, env_table, config)
+    return
+  end
 
   -- Terminal exists, is valid, but not visible
   if terminal and terminal:buf_valid() and not terminal:win_valid() then


### PR DESCRIPTION
## Problem

`:ClaudeCode --resume` and `:ClaudeCode --continue` only work on a **fresh Neovim session** with no prior Claude terminal. If a Claude terminal was opened earlier in the session (even if hidden), `simple_toggle` and `focus_toggle` reuse the existing terminal and silently ignore the command args.

**Root cause:** Both `native.lua` and `snacks.lua` providers check if a terminal buffer already exists. If it does, they show/hide it without ever passing `cmd_string` to the terminal process — so flags like `--resume` are dropped.

## Fix

Add a `force_new` boolean parameter that propagates from `terminal.lua` through to both providers. When `force_new` is true (i.e. `cmd_args` was non-empty), the existing terminal is closed first, then a fresh session is opened with the supplied command args.

**Affected functions:**
- `terminal.lua`: `simple_toggle`, `focus_toggle` — set `force_new = cmd_args ~= nil and cmd_args ~= ""`
- `terminal/native.lua`: `simple_toggle`, `focus_toggle` — handle `force_new`
- `terminal/snacks.lua`: `simple_toggle`, `focus_toggle` — handle `force_new`

## Behaviour after fix

| Command | Before | After |
|---|---|---|
| `:ClaudeCode --resume` (terminal exists) | Shows existing session, ignores `--resume` | Closes existing, opens resume picker |
| `:ClaudeCode --continue` (terminal exists) | Shows existing session, ignores `--continue` | Closes existing, resumes last session |
| `:ClaudeCode` (no args) | Unchanged | Unchanged |

## Related

- Closes #147
- Related to #17 (original `--resume`/`--continue` feature request, partially fixed by #31 but only worked on fresh sessions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)