### PR TITLE
feat: support shift+enter in native terminal

### DIFF
--- a/lua/claudecode/terminal/native.lua
+++ b/lua/claudecode/terminal/native.lua
@@ -134,6 +134,14 @@ local function open_terminal(cmd_string, env_table, effective_config, focus)
   vim.bo[bufnr].bufhidden = "hide"
   -- buftype=terminal is set by termopen
 
+  -- Shift+Enter inserts a line continuation (backslash + newline) in the terminal
+  vim.keymap.set("t", "<S-CR>", function()
+    vim.api.nvim_feedkeys("\\", "t", true)
+    vim.defer_fn(function()
+      vim.api.nvim_feedkeys("\r", "t", true)
+    end, 10)
+  end, { buffer = bufnr, desc = "New line" })
+
   if focus then
     -- Focus the terminal: switch to terminal window and enter insert mode
     vim.api.nvim_set_current_win(winid)

--- a/tests/unit/native_terminal_toggle_spec.lua
+++ b/tests/unit/native_terminal_toggle_spec.lua
@@ -151,6 +151,9 @@ describe("claudecode.terminal.native toggle behavior", function()
           return jobid
         end,
       },
+      keymap = {
+        set = function() end,
+      },
       schedule = function(callback)
         callback() -- Execute immediately in tests
       end,


### PR DESCRIPTION
This was implemented for the snacks terminal in https://github.com/coder/claudecode.nvim/issues/79 (PR: https://github.com/coder/claudecode.nvim/pull/116) but not the native one.

Fix for https://github.com/coder/claudecode.nvim/issues/200

Making this a draft for now. It would be better if the keymap were limited to this buffer, which I could do with https://github.com/coder/claudecode.nvim/pull/202