### PR TITLE
feat: make terminal buffer filter configurable

### DIFF
--- a/lua/claudecode/config.lua
+++ b/lua/claudecode/config.lua
@@ -14,6 +14,7 @@ M.defaults = {
   env = {}, -- Custom environment variables for Claude terminal
   log_level = "info",
   track_selection = true,
+  terminal_filter_pattern = "^term://.*claude",
   -- When true, focus Claude terminal after a successful send while connected
   focus_after_send = false,
   visual_demotion_delay_ms = 50, -- Milliseconds to wait before demoting a visual selection

--- a/lua/claudecode/init.lua
+++ b/lua/claudecode/init.lua
@@ -471,7 +471,7 @@ function M.start(show_startup_notification)
 
   if M.state.config.track_selection then
     local selection = require("claudecode.selection")
-    selection.enable(M.state.server, M.state.config.visual_demotion_delay_ms)
+    selection.enable(M.state.server, M.state.config.visual_demotion_delay_ms, M.state.config.terminal_filter_pattern)
   end
 
   if show_startup_notification then

--- a/lua/claudecode/selection.lua
+++ b/lua/claudecode/selection.lua
@@ -14,12 +14,13 @@ M.state = {
   last_active_visual_selection = nil,
   demotion_timer = nil,
   visual_demotion_delay_ms = 50,
+  terminal_filter_pattern = nil,
 }
 
 ---Enables selection tracking.
 ---@param server table The server object to use for communication.
 ---@param visual_demotion_delay_ms number The delay for visual selection demotion.
-function M.enable(server, visual_demotion_delay_ms)
+function M.enable(server, visual_demotion_delay_ms, terminal_filter_pattern)
   if M.state.tracking_enabled then
     return
   end
@@ -27,6 +28,7 @@ function M.enable(server, visual_demotion_delay_ms)
   M.state.tracking_enabled = true
   M.server = server
   M.state.visual_demotion_delay_ms = visual_demotion_delay_ms
+  M.state.terminal_filter_pattern = terminal_filter_pattern
 
   M._create_autocommands()
 end
@@ -129,7 +131,7 @@ function M.update_selection()
   local buf_name = vim.api.nvim_buf_get_name(current_buf)
 
   -- If the buffer name starts with "term://" and contains "claude", do not update selection
-  if buf_name and buf_name:match("^term://") and buf_name:lower():find("claude", 1, true) then
+  if M.state.terminal_filter_pattern and buf_name and buf_name:lower():match(M.state.terminal_filter_pattern) then
     -- Optionally, cancel demotion timer like for the terminal
     if M.state.demotion_timer then
       M.state.demotion_timer:stop()

--- a/lua/claudecode/types.lua
+++ b/lua/claudecode/types.lua
@@ -108,6 +108,7 @@
 ---@field env table<string, string>
 ---@field log_level ClaudeCodeLogLevel
 ---@field track_selection boolean
+---@field terminal_filter_pattern string
 ---@field focus_after_send boolean
 ---@field visual_demotion_delay_ms number
 ---@field connection_wait_delay number


### PR DESCRIPTION
Adds `terminal_filter_pattern` config option for customizing which terminal buffers are excluded from selection tracking. Useful when Claude runs in external terminals (e.g. sidekick.nvim with tmux) where the buffer name doesn't contain "claude".

Fixes #206