### PR TITLE
fix(diff): wipe empty buffer when terminal provider is none

### DIFF
--- a/fixtures/issue-208/init.lua
+++ b/fixtures/issue-208/init.lua
@@ -1,0 +1,224 @@
+-- Fixture for issue #208:
+--   "[BUG] Leftover [No Name] tab after diff resolve with open_in_new_tab and
+--    terminal.provider = none"
+--   https://github.com/coder/claudecode.nvim/issues/208
+--
+-- Repro config from the report:
+--   terminal  = { provider = "none" }        -- Claude runs in an EXTERNAL terminal
+--   diff_opts = { open_in_new_tab = true }   -- each diff opens in its own tab
+--
+-- With provider = "none" there is no in-Neovim terminal buffer, so the new-tab
+-- helper (display_terminal_in_new_tab) early-returns right after `:tabnew`
+-- WITHOUT marking the bare `[No Name]` buffer ephemeral, and reports "no terminal
+-- window". choose_original_window() then treats the diff as NOT in a new tab and
+-- REUSES that empty buffer as the diff's original side. On a NEW-file diff that
+-- reused buffer is never deleted on cleanup (original_buffer_created_by_plugin is
+-- false), so it leaks -- "collecting empty buffers on every new diff tab".
+--
+-- This fixture drives the diff through the exact functions the openDiff /
+-- close_tab MCP path uses, so NO external Claude is required to see the leak.
+--
+-- Usage (from repo root):
+--   source fixtures/nvim-aliases.sh && vv issue-208
+-- Watch the tabline counter "noname=N". Then:
+--   <leader>x          open+ACCEPT a NEW-file diff      -> noname count GROWS  (BUG)
+--   :Repro208NewReject open+REJECT a NEW-file diff      -> noname count GROWS  (BUG)
+--   :Repro208Existing  open+accept an EXISTING-file diff-> noname count steady (control)
+--   :Repro208Buffers   print the leaked [No Name] buffers (:ls-style)
+--   :Repro208Reset     collapse to one tab + wipe stray no-name buffers
+
+local config_dir = vim.fn.stdpath("config")
+local repo_root = vim.fn.fnamemodify(config_dir, ":h:h")
+vim.opt.rtp:prepend(repo_root)
+
+vim.g.mapleader = " "
+vim.g.maplocalleader = "\\"
+
+-- Count valid, listed buffers with an empty name -> the leaked `[No Name]` buffers.
+local function noname_count()
+  local n = 0
+  for _, b in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_valid(b) and vim.api.nvim_buf_get_name(b) == "" and vim.bo[b].buflisted then
+      n = n + 1
+    end
+  end
+  return n
+end
+
+-- Always show the tabline with a live [No Name] buffer counter, so the leak is
+-- visible without typing any command.
+vim.o.showtabline = 2
+vim.o.laststatus = 2
+function _G.Repro208Tabline()
+  local s = {}
+  for i = 1, vim.fn.tabpagenr("$") do
+    local active = (i == vim.fn.tabpagenr())
+    local winnr = vim.fn.tabpagewinnr(i)
+    local buflist = vim.fn.tabpagebuflist(i)
+    local bufname = vim.fn.bufname(buflist[winnr])
+    local label = (bufname == "" and "[No Name]" or vim.fn.fnamemodify(bufname, ":t"))
+    s[#s + 1] = (active and "%#TabLineSel#" or "%#TabLine#")
+    s[#s + 1] = (" TAB %d%s: %s "):format(i, active and " (active)" or "", label)
+  end
+  s[#s + 1] = "%#TabLineFill#"
+  s[#s + 1] = "%=%#WarningMsg# noname=" .. noname_count() .. "  tabs=" .. vim.fn.tabpagenr("$") .. " "
+  return table.concat(s)
+end
+vim.o.tabline = "%!v:lua.Repro208Tabline()"
+
+local ok, claudecode = pcall(require, "claudecode")
+assert(ok, "Failed to load claudecode.nvim from repo root: " .. tostring(claudecode))
+
+claudecode.setup({
+  auto_start = false,
+  log_level = "info",
+  terminal = {
+    provider = "none", -- the path under test (#208): Claude runs externally
+  },
+  diff_opts = {
+    layout = "vertical",
+    open_in_new_tab = true, -- the path under test (#208)
+    keep_terminal_focus = false,
+    on_new_file_reject = "keep_empty",
+  },
+})
+
+local diff = require("claudecode.diff")
+
+-- Drive one diff through the real MCP code path with no external Claude:
+--   open  -> M._setup_blocking_diff  (what the openDiff tool runs)
+--   accept-> M._resolve_diff_as_saved (what BufWriteCmd / :w runs)
+--   reject-> M._resolve_diff_as_rejected (what the reject keymap runs)
+--   close -> M.close_diff_by_tab_name (what Claude's close_tab notification runs)
+---@param is_new_file boolean
+---@param mode "accept"|"reject"
+local function run_one(is_new_file, mode)
+  local before = noname_count()
+
+  local tag = (is_new_file and "new" or "existing") .. "_" .. mode
+  local tab_name = ("✻ [Claude Code] issue208_%s ⧉"):format(tag)
+
+  local old_file
+  if is_new_file then
+    old_file = vim.fn.tempname() .. "_issue208_" .. tag .. "_NEW.md" -- not created -> is_new_file
+  else
+    old_file = vim.fn.tempname() .. "_issue208_" .. tag .. ".md"
+    local fh = io.open(old_file, "w")
+    fh:write("# original\n\nline one\nline two\n")
+    fh:close()
+  end
+
+  pcall(function()
+    diff._setup_blocking_diff({
+      old_file_path = old_file,
+      new_file_path = old_file,
+      new_file_contents = "# proposed by Claude\n\nNEW line one\nline two\n",
+      tab_name = tab_name,
+    }, function() end)
+    local active = diff._get_active_diffs()[tab_name]
+    if mode == "accept" then
+      if active and active.new_buffer then
+        diff._resolve_diff_as_saved(tab_name, active.new_buffer)
+      end
+    else
+      diff._resolve_diff_as_rejected(tab_name)
+    end
+    diff.close_diff_by_tab_name(tab_name)
+  end)
+
+  -- close_diff_by_tab_name's saved branch defers a reload by 100ms.
+  vim.wait(250, function()
+    return false
+  end)
+  if not is_new_file then
+    os.remove(old_file)
+  end
+
+  local after = noname_count()
+  local delta = after - before
+  vim.api.nvim_echo({
+    {
+      ("issue208 [%s]: [No Name] bufs %d -> %d (delta=%+d)%s"):format(
+        tag,
+        before,
+        after,
+        delta,
+        delta > 0 and "  <<< LEAKED" or "  (clean)"
+      ),
+      delta > 0 and "ErrorMsg" or "MoreMsg",
+    },
+  }, false, {})
+end
+
+vim.api.nvim_create_user_command("Repro208New", function()
+  run_one(true, "accept")
+end, { desc = "#208: open+ACCEPT a NEW-file diff (leaks a [No Name] buffer)" })
+
+vim.api.nvim_create_user_command("Repro208NewReject", function()
+  run_one(true, "reject")
+end, { desc = "#208: open+REJECT a NEW-file diff (leaks a [No Name] buffer)" })
+
+vim.api.nvim_create_user_command("Repro208Existing", function()
+  run_one(false, "accept")
+end, { desc = "#208: open+accept an EXISTING-file diff (control, clean)" })
+
+vim.api.nvim_create_user_command("Repro208Buffers", function()
+  local lines = { "Leaked [No Name] listed buffers:" }
+  for _, b in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_valid(b) and vim.api.nvim_buf_get_name(b) == "" and vim.bo[b].buflisted then
+      local loaded = vim.api.nvim_buf_is_loaded(b)
+      lines[#lines + 1] = ("  buf %d  loaded=%s  lines=%d"):format(
+        b,
+        tostring(loaded),
+        loaded and vim.api.nvim_buf_line_count(b) or -1
+      )
+    end
+  end
+  lines[#lines + 1] = ("total noname=%d  tabs=%d"):format(noname_count(), vim.fn.tabpagenr("$"))
+  vim.api.nvim_echo({ { table.concat(lines, "\n"), "MoreMsg" } }, true, {})
+end, { desc = "#208: list leaked [No Name] buffers" })
+
+vim.api.nvim_create_user_command("Repro208Reset", function()
+  diff._cleanup_all_active_diffs("repro reset")
+  vim.cmd("silent! tabonly!")
+  vim.cmd("silent! only!")
+  vim.cmd("silent! enew!")
+  local cur = vim.api.nvim_get_current_buf()
+  for _, b in ipairs(vim.api.nvim_list_bufs()) do
+    if b ~= cur and vim.api.nvim_buf_is_valid(b) and vim.api.nvim_buf_get_name(b) == "" and vim.bo[b].buflisted then
+      pcall(vim.api.nvim_buf_delete, b, { force = true })
+    end
+  end
+  vim.api.nvim_echo(
+    { { ("Repro208Reset: noname=%d  tabs=%d"):format(noname_count(), vim.fn.tabpagenr("$")), "MoreMsg" } },
+    false,
+    {}
+  )
+end, { desc = "#208: reset layout + wipe stray no-name buffers" })
+
+vim.keymap.set("n", "<leader>x", function()
+  run_one(true, "accept")
+end, { desc = "#208 repro: open+accept a NEW-file diff" })
+
+-- A normal editor buffer in the first tab so the layout looks like real usage.
+local banner = {
+  "claudecode.nvim -- issue #208 reproduction fixture",
+  "",
+  "terminal.provider   = none      (Claude runs in an external terminal)",
+  "diff_opts.open_in_new_tab = true (each diff opens in its own tab)",
+  "",
+  "Watch the tabline (top-right): noname=N  tabs=M",
+  "",
+  "  <leader>x           open+ACCEPT a NEW-file diff   -> noname GROWS (BUG #208)",
+  "  :Repro208NewReject  open+REJECT a NEW-file diff   -> noname GROWS (BUG #208)",
+  "  :Repro208Existing   open+accept EXISTING file     -> noname steady (control)",
+  "  :Repro208Buffers    print the leaked [No Name] buffers",
+  "  :Repro208Reset      collapse to one tab + wipe stray buffers",
+  "",
+  "Each NEW-file diff leaves one extra unnamed buffer behind (both accept and",
+  "reject). Existing-file diffs are clean because the reused empty buffer is",
+  "`:edit`-ed over and auto-wiped.",
+}
+vim.api.nvim_buf_set_lines(0, 0, -1, false, banner)
+vim.bo.modifiable = false
+vim.bo.modified = false

--- a/lua/claudecode/diff.lua
+++ b/lua/claudecode/diff.lua
@@ -310,6 +310,21 @@ local function get_default_terminal_options()
   }
 end
 
+---Mark the current buffer (just created by tabnew) as ephemeral so it auto-wipes when hidden.
+local function mark_tabnew_buffer_ephemeral()
+  local buf = vim.api.nvim_get_current_buf()
+  local ok_name, name = pcall(vim.api.nvim_buf_get_name, buf)
+  local ok_mod, modified = pcall(vim.api.nvim_buf_get_option, buf, "modified")
+  local ok_lc, linecount = pcall(function()
+    return vim.api.nvim_buf_line_count(buf)
+  end)
+  if ok_name and ok_mod and ok_lc then
+    if (name == nil or name == "") and modified == false and linecount <= 1 then
+      pcall(vim.api.nvim_buf_set_option, buf, "bufhidden", "wipe")
+    end
+  end
+end
+
 ---Display existing Claude Code terminal in new tab
 ---@return number original_tab The original tab number
 ---@return number? terminal_win Terminal window in new tab
@@ -322,6 +337,7 @@ local function display_terminal_in_new_tab()
   local terminal_ok, terminal_module = pcall(require, "claudecode.terminal")
   if not terminal_ok then
     vim.cmd("tabnew")
+    mark_tabnew_buffer_ephemeral()
     local new_tab = vim.api.nvim_get_current_tabpage()
     return original_tab, nil, false, new_tab
   end
@@ -329,6 +345,7 @@ local function display_terminal_in_new_tab()
   local terminal_bufnr = terminal_module.get_active_terminal_bufnr()
   if not terminal_bufnr or not vim.api.nvim_buf_is_valid(terminal_bufnr) then
     vim.cmd("tabnew")
+    mark_tabnew_buffer_ephemeral()
     local new_tab = vim.api.nvim_get_current_tabpage()
     return original_tab, nil, false, new_tab
   end
@@ -343,21 +360,8 @@ local function display_terminal_in_new_tab()
   end
 
   vim.cmd("tabnew")
+  mark_tabnew_buffer_ephemeral()
   local new_tab = vim.api.nvim_get_current_tabpage()
-
-  -- Mark the initial, unnamed buffer in the new tab as ephemeral to avoid leaks
-  -- When this buffer gets hidden (replaced or tab closed), wipe it automatically.
-  local initial_buf = vim.api.nvim_get_current_buf()
-  local name_ok, initial_name = pcall(vim.api.nvim_buf_get_name, initial_buf)
-  local mod_ok, initial_modified = pcall(vim.api.nvim_buf_get_option, initial_buf, "modified")
-  local linecount_ok, initial_linecount = pcall(function()
-    return vim.api.nvim_buf_line_count(initial_buf)
-  end)
-  if name_ok and mod_ok and linecount_ok then
-    if (initial_name == nil or initial_name == "") and initial_modified == false and initial_linecount <= 1 then
-      pcall(vim.api.nvim_buf_set_option, initial_buf, "bufhidden", "wipe")
-    end
-  end
 
   local terminal_config = config.terminal or {}
   local split_side = terminal_config.split_side or "right"

--- a/scripts/repro_issue_208.lua
+++ b/scripts/repro_issue_208.lua
@@ -1,0 +1,310 @@
+-- Reproduction / verification for issue #208:
+--   "[BUG] Leftover [No Name] tab after diff resolve with open_in_new_tab and
+--    terminal.provider = none"
+--   https://github.com/coder/claudecode.nvim/issues/208
+--
+-- Scenario from the report:
+--   opts = {
+--     terminal  = { provider = "none" },          -- Claude runs in an EXTERNAL terminal
+--     diff_opts = { open_in_new_tab = true },     -- each diff opens in its own tab
+--   }
+-- Resolving a diff (accept AND reject) leaves behind an empty `[No Name]` tab /
+-- buffer that is never cleaned up. A commenter confirms: "We start collecting
+-- empty buffers on every new diff tab."
+--
+-- Why provider = "none" matters
+-- ------------------------------
+-- diff.lua opens the new tab via display_terminal_in_new_tab(). With a terminal
+-- (snacks/native) it runs the full path that marks the initial unnamed buffer
+-- `bufhidden=wipe` (diff.lua ~320-332). With provider = "none" there is no
+-- terminal buffer, so the helper EARLY-RETURNS at the `:tabnew` site
+-- (diff.lua ~303-306) WITHOUT marking that buffer ephemeral, and returns
+-- terminal_win_in_new_tab = nil. choose_original_window() derives
+-- `in_new_tab = terminal_win_in_new_tab ~= nil` (diff.lua ~565), so it thinks it
+-- is NOT in a new tab and REUSES the bare `[No Name]` buffer as the diff's
+-- original side -- a buffer that is never marked ephemeral and (for new files)
+-- never deleted on cleanup because original_buffer_created_by_plugin = false.
+--
+-- This script drives the REAL diff.lua against the open_in_new_tab path with no
+-- WebSocket / Claude CLI. It exercises the exact functions the MCP layer calls:
+--   * open:    M._setup_blocking_diff (what the openDiff tool runs)
+--   * accept:  M._resolve_diff_as_saved  + M.close_diff_by_tab_name (close_tab)
+--   * reject:  M._resolve_diff_as_rejected + M.close_diff_by_tab_name (close_tab)
+-- (Accept/reject themselves intentionally do NOT touch tabs/windows; cleanup is
+-- driven exclusively by Claude's close_tab call -> _cleanup_diff_state. See the
+-- NOTE comments in _resolve_diff_as_saved / deny_current_diff.)
+--
+-- Run from the repo root:
+--   nvim --headless -u NONE -l scripts/repro_issue_208.lua
+--
+-- Exit code: 1 if ANY scenario leaks a tab or a `[No Name]` buffer (#208
+-- reproduced), 0 if all clean. The detailed verdict is printed either way.
+
+local script_path = debug.getinfo(1, "S").source:sub(2)
+local repo_root = vim.fn.fnamemodify(script_path, ":h:h")
+vim.opt.rtp:prepend(repo_root)
+
+local function out(msg)
+  io.stdout:write(msg .. "\n")
+end
+
+local diff = require("claudecode.diff")
+
+-- Force the provider = "none" code path deterministically: pre-load the terminal
+-- module and make get_active_terminal_bufnr() report "no terminal", so
+-- display_terminal_in_new_tab() takes the early-return `:tabnew` branch
+-- regardless of the host environment. This is exactly what provider = "none"
+-- produces at runtime (no terminal buffer ever exists).
+local terminal = require("claudecode.terminal")
+terminal.get_active_terminal_bufnr = function()
+  return nil
+end
+
+diff.setup({
+  diff_opts = {
+    layout = "vertical",
+    open_in_new_tab = true, -- the path under test
+    keep_terminal_focus = false,
+    on_new_file_reject = "keep_empty",
+  },
+  terminal = { provider = "none" },
+})
+
+local function count_tabs()
+  return vim.fn.tabpagenr("$")
+end
+
+-- Set of valid, listed buffers whose name is empty -> these are the `[No Name]`
+-- buffers the issue is about. Returned as a handle->true map so we can diff two
+-- snapshots and report only NEWLY-leaked buffers.
+local function noname_bufs()
+  local set = {}
+  for _, b in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_valid(b) then
+      local name = vim.api.nvim_buf_get_name(b)
+      local listed = vim.api.nvim_buf_get_option(b, "buflisted")
+      if name == "" and listed then
+        set[b] = true
+      end
+    end
+  end
+  return set
+end
+
+local function set_diff(after, before)
+  local new = {}
+  for b in pairs(after) do
+    if not before[b] then
+      new[#new + 1] = b
+    end
+  end
+  return new
+end
+
+-- Collapse to a single clean tab/window so each scenario starts fresh, then wipe
+-- every stray `[No Name]` buffer so the per-scenario baseline is genuinely empty.
+local function reset_layout()
+  vim.cmd("silent! tabonly!")
+  vim.cmd("silent! only!")
+  vim.cmd("silent! enew!")
+  diff._cleanup_all_active_diffs("repro reset")
+  -- Wipe leaked no-name buffers from a previous scenario (except the current one).
+  local cur = vim.api.nvim_get_current_buf()
+  for b in pairs(noname_bufs()) do
+    if b ~= cur then
+      pcall(vim.api.nvim_buf_delete, b, { force = true })
+    end
+  end
+end
+
+local function make_old_file(tag)
+  local p = vim.fn.tempname() .. "_" .. tag .. ".md"
+  local fh = io.open(p, "w")
+  fh:write("# original\n\nline one\nline two\n")
+  fh:close()
+  return p
+end
+
+-- A path that does NOT exist on disk -> is_new_file = true inside diff.lua.
+local function make_new_file_path(tag)
+  return vim.fn.tempname() .. "_" .. tag .. "_new.md"
+end
+
+---@param name string
+---@param is_new_file boolean
+---@param mode "accept"|"reject"
+local function run_scenario(name, is_new_file, mode)
+  reset_layout()
+
+  local tabs_before = count_tabs()
+  local noname_before = noname_bufs()
+  local orig_tab = vim.api.nvim_get_current_tabpage()
+
+  local tab_name = ("✻ [Claude Code] repro208_%s ⧉"):format(name)
+  local old_file
+  if is_new_file then
+    old_file = make_new_file_path(name)
+  else
+    old_file = make_old_file(name)
+  end
+
+  local setup_ok, setup_err = pcall(function()
+    diff._setup_blocking_diff({
+      old_file_path = old_file,
+      new_file_path = old_file,
+      new_file_contents = "# proposed by Claude\n\nNEW line one\nline two\n",
+      tab_name = tab_name,
+    }, function() end)
+  end)
+
+  local tabs_during = count_tabs()
+
+  -- Resolve exactly as the MCP layer does.
+  if setup_ok then
+    local active = diff._get_active_diffs()[tab_name]
+    if mode == "accept" then
+      -- :w in the proposed buffer -> BufWriteCmd -> _resolve_diff_as_saved
+      if active and active.new_buffer then
+        diff._resolve_diff_as_saved(tab_name, active.new_buffer)
+      end
+    else
+      -- reject keymap / :q -> _resolve_diff_as_rejected
+      diff._resolve_diff_as_rejected(tab_name)
+    end
+    -- Claude then sends close_tab -> close_diff_by_tab_name -> _cleanup_diff_state
+    diff.close_diff_by_tab_name(tab_name)
+  end
+
+  -- close_diff_by_tab_name's saved branch defers a buffer reload by 100ms; give
+  -- any deferred work a chance to run before we measure.
+  vim.wait(250, function()
+    return false
+  end)
+
+  local tabs_after = count_tabs()
+  local noname_after = noname_bufs()
+  local cur_tab = vim.api.nvim_get_current_tabpage()
+
+  local leaked_tab = tabs_after > tabs_before
+  local leaked_bufs = set_diff(noname_after, noname_before)
+  local refocused = cur_tab == orig_tab
+
+  out(("\n[%s | %s | %s]"):format(name, is_new_file and "NEW file" or "existing file", mode))
+  out(("  setup            : %s"):format(setup_ok and "OK" or ("ERROR -- " .. tostring(setup_err))))
+  out(
+    ("  tabs             : before=%d  during=%d  after=%d  %s"):format(
+      tabs_before,
+      tabs_during,
+      tabs_after,
+      leaked_tab and "<< LEFTOVER TAB" or "(tab cleaned)"
+    )
+  )
+  out(
+    ("  [No Name] bufs   : before=%d  after=%d  leaked=%d  %s"):format(
+      vim.tbl_count(noname_before),
+      vim.tbl_count(noname_after),
+      #leaked_bufs,
+      (#leaked_bufs > 0) and ("<< LEAKED " .. vim.inspect(leaked_bufs):gsub("%s+", " ")) or "(no buffer leak)"
+    )
+  )
+  out(("  focus            : %s"):format(refocused and "back on original tab" or "left elsewhere"))
+
+  os.remove(old_file)
+
+  return {
+    name = name,
+    is_new_file = is_new_file,
+    mode = mode,
+    leaked_tab = leaked_tab,
+    leaked_bufs = #leaked_bufs,
+  }
+end
+
+out("== issue #208 reproduction (open_in_new_tab + provider=none leaves [No Name] tab/buffer) ==")
+out(("Neovim: %s"):format(tostring(vim.version())))
+
+local results = {}
+results[#results + 1] = run_scenario("existing_accept", false, "accept")
+results[#results + 1] = run_scenario("existing_reject", false, "reject")
+results[#results + 1] = run_scenario("new_accept", true, "accept")
+results[#results + 1] = run_scenario("new_reject", true, "reject")
+
+-- Accumulation check: open+resolve several diffs in a row WITHOUT wiping no-name
+-- buffers between them, to confirm the reported "collecting empty buffers on
+-- every new diff tab". Uses existing-file accept (the most common real action).
+out("\n[accumulation: 3x existing-file accept, no buffer wipe between]")
+vim.cmd("silent! tabonly!")
+vim.cmd("silent! only!")
+vim.cmd("silent! enew!")
+diff._cleanup_all_active_diffs("accum reset")
+for b in pairs(noname_bufs()) do
+  if b ~= vim.api.nvim_get_current_buf() then
+    pcall(vim.api.nvim_buf_delete, b, { force = true })
+  end
+end
+local accum_before = vim.tbl_count(noname_bufs())
+for i = 1, 3 do
+  local tab_name = ("✻ [Claude Code] repro208_accum_%d ⧉"):format(i)
+  local old_file = make_old_file("accum_" .. i)
+  pcall(function()
+    diff._setup_blocking_diff({
+      old_file_path = old_file,
+      new_file_path = old_file,
+      new_file_contents = "# proposed " .. i .. "\n\nNEW line one\nline two\n",
+      tab_name = tab_name,
+    }, function() end)
+    local active = diff._get_active_diffs()[tab_name]
+    if active and active.new_buffer then
+      diff._resolve_diff_as_saved(tab_name, active.new_buffer)
+    end
+    diff.close_diff_by_tab_name(tab_name)
+  end)
+  vim.wait(200, function()
+    return false
+  end)
+  os.remove(old_file)
+end
+local accum_after = vim.tbl_count(noname_bufs())
+local accum_tabs = count_tabs()
+out(
+  ("  [No Name] bufs   : before=%d  after 3 diffs=%d  (delta=%d)"):format(
+    accum_before,
+    accum_after,
+    accum_after - accum_before
+  )
+)
+out(("  tabs             : after 3 diffs=%d %s"):format(accum_tabs, accum_tabs > 1 and "<< LEFTOVER TABS" or "(clean)"))
+
+out("\n== verdict ==")
+local any_leak = false
+for _, r in ipairs(results) do
+  local leak = r.leaked_tab or r.leaked_bufs > 0
+  any_leak = any_leak or leak
+  out(
+    ("  %-16s %-13s %-7s : %s"):format(
+      r.name,
+      r.is_new_file and "NEW file" or "existing",
+      r.mode,
+      leak and (("LEAK (tab=%s, bufs=%d)"):format(tostring(r.leaked_tab), r.leaked_bufs)) or "clean"
+    )
+  )
+end
+local accum_leak = (accum_after - accum_before) > 0 or accum_tabs > 1
+any_leak = any_leak or accum_leak
+out(
+  ("  %-16s %-13s %-7s : %s"):format(
+    "accumulation",
+    "existing",
+    "3x accept",
+    accum_leak and (("LEAK (%d buffers, %d tabs)"):format(accum_after - accum_before, accum_tabs)) or "clean"
+  )
+)
+
+if any_leak then
+  out("\n=> #208 confirmed: open_in_new_tab + provider=none leaks a [No Name] tab and/or buffer on diff resolve.")
+else
+  out("\n=> FIXED: no leftover tab or [No Name] buffer after diff resolve.")
+end
+
+io.stdout:flush()
+vim.cmd("cquit " .. (any_leak and 1 or 0))


### PR DESCRIPTION
Extract the marking of the current buffer to ephemeral when tabnew is applied.

Use this function at every early return site where `vim.cmd(tabnew)` is called.

Fixes: #208