### PR TITLE
feat: add reposition method to snacks terminal provider

### DIFF
--- a/lua/claudecode/terminal.lua
+++ b/lua/claudecode/terminal.lua
@@ -557,6 +557,17 @@ function M.get_active_terminal_bufnr()
   return get_provider().get_active_bufnr()
 end
 
+---Reposition the terminal window with new opts, keeping the process alive.
+---@param opts_override table? Overrides (e.g. snacks_win_opts with new position)
+function M.reposition(opts_override)
+  local effective_config = build_config(opts_override)
+  local cmd_string, claude_env_table = get_claude_command_and_env()
+  local provider = get_provider()
+  if type(provider.reposition) == "function" then
+    provider.reposition(cmd_string, claude_env_table, effective_config)
+  end
+end
+
 ---Gets the managed terminal instance for testing purposes.
 -- NOTE: This function is intended for use in tests to inspect internal state.
 -- The underscore prefix indicates it's not part of the public API for regular use.

--- a/lua/claudecode/terminal/snacks.lua
+++ b/lua/claudecode/terminal/snacks.lua
@@ -266,6 +266,25 @@ function M.is_available()
   return is_available()
 end
 
+---Reposition the terminal window using new config, keeping the terminal process alive.
+---Closes the current window (not the buffer), then reopens with new position/opts.
+---@param cmd_string string
+---@param env_table table
+---@param config table
+function M.reposition(cmd_string, env_table, config)
+  if not is_available() or not terminal or not terminal:buf_valid() then
+    return
+  end
+  local buf = terminal.buf
+  terminal:close({ buf = false })
+  local opts = build_opts(config, env_table, true)
+  opts.win.buf = buf
+  local new_term = Snacks.win(opts.win)
+  if new_term and new_term:buf_valid() then
+    terminal = new_term
+  end
+end
+
 ---For testing purposes
 ---@return table? terminal The terminal instance, or nil
 function M._get_terminal_for_test()


### PR DESCRIPTION
## Summary

- Adds `M.reposition()` to `lua/claudecode/terminal/snacks.lua` that closes the current window (without killing the terminal process) and reopens the existing buffer in a new `Snacks.win` with different position opts
- Exposes `M.reposition(opts_override)` on the public `lua/claudecode/terminal.lua` module, delegating to the provider if supported
- Snacks-only: the call is guarded by `if type(provider.reposition) == "function"` so native/external providers are unaffected

## Usage

```lua
local base_win_opts = opts.terminal.snacks_win_opts
local is_float = true
vim.api.nvim_create_user_command("ClaudeTogglePosition", function()
  local term = require("claudecode.terminal")
  if is_float then
    term.reposition({ snacks_win_opts = vim.tbl_extend("force", base_win_opts, { position = "right", width = 0.4 }) })
  else
    term.reposition({ snacks_win_opts = base_win_opts })
  end
  is_float = not is_float
end, {})
```

Closes #225