### PR TITLE
feat: fire User autocmds for plugin state changes

### DIFF
--- a/lua/claudecode/diff.lua
+++ b/lua/claudecode/diff.lua
@@ -704,6 +704,7 @@ function M._open_native_diff(old_file_path, new_file_path, new_file_contents, ta
     once = true,
   })
 
+  vim.api.nvim_exec_autocmds("User", { pattern = "ClaudeCodeDiffOpened", modeline = false })
   return {
     provider = "native",
     tab_name = tab_name,
@@ -753,6 +754,7 @@ function M._resolve_diff_as_saved(tab_name, buffer_id)
 
   diff_data.status = "saved"
   diff_data.result_content = result
+  vim.api.nvim_exec_autocmds("User", { pattern = "ClaudeCodeDiffClosed", modeline = false })
 
   -- Resume the coroutine with the result (for deferred response system)
   if diff_data.resolution_callback then
@@ -828,6 +830,7 @@ function M._resolve_diff_as_rejected(tab_name)
 
   diff_data.status = "rejected"
   diff_data.result_content = result
+  vim.api.nvim_exec_autocmds("User", { pattern = "ClaudeCodeDiffClosed", modeline = false })
 
   -- Resume the coroutine with the result (for deferred response system)
   if diff_data.resolution_callback then

--- a/lua/claudecode/server/init.lua
+++ b/lua/claudecode/server/init.lua
@@ -65,6 +65,9 @@ function M.start(config, auth_token)
           main_module.process_mention_queue(true)
         end)
       end
+      vim.schedule(function()
+        vim.api.nvim_exec_autocmds("User", { pattern = "ClaudeCodeConnected", modeline = false })
+      end)
     end,
     on_disconnect = function(client, code, reason)
       logger.debug(
@@ -76,6 +79,9 @@ function M.start(config, auth_token)
         ", reason:",
         (reason or "N/A") .. ")"
       )
+      vim.schedule(function()
+        vim.api.nvim_exec_autocmds("User", { pattern = "ClaudeCodeDisconnected", modeline = false })
+      end)
     end,
     on_error = function(error_msg)
       logger.error("server", "WebSocket server error:", error_msg)

--- a/lua/claudecode/terminal/native.lua
+++ b/lua/claudecode/terminal/native.lua
@@ -147,6 +147,7 @@ local function open_terminal(cmd_string, env_table, effective_config, focus)
     vim.notify("Native terminal opened. Press Ctrl-\\ Ctrl-N to return to Normal mode.", vim.log.levels.INFO)
     tip_shown = true
   end
+  vim.api.nvim_exec_autocmds("User", { pattern = "ClaudeCodeTerminalOpened", modeline = false })
   return true
 end
 
@@ -196,6 +197,7 @@ local function hide_terminal()
     winid = nil -- Clear window reference
 
     logger.debug("terminal", "Terminal window hidden, process preserved")
+    vim.api.nvim_exec_autocmds("User", { pattern = "ClaudeCodeTerminalHidden", modeline = false })
   end
 end
 
@@ -244,6 +246,7 @@ local function show_hidden_terminal(effective_config, focus)
   end
 
   logger.debug("terminal", "Showed hidden terminal in new window")
+  vim.api.nvim_exec_autocmds("User", { pattern = "ClaudeCodeTerminalOpened", modeline = false })
   return true
 end
 

--- a/lua/claudecode/terminal/snacks.lua
+++ b/lua/claudecode/terminal/snacks.lua
@@ -98,6 +98,7 @@ function M.open(cmd_string, env_table, config, focus)
     if not terminal.win or not vim.api.nvim_win_is_valid(terminal.win) then
       -- Terminal is hidden, show it using snacks toggle
       terminal:toggle()
+      vim.api.nvim_exec_autocmds("User", { pattern = "ClaudeCodeTerminalOpened", modeline = false })
       if focus then
         terminal:focus()
         local term_buf_id = terminal.buf
@@ -132,6 +133,7 @@ function M.open(cmd_string, env_table, config, focus)
   if term_instance and term_instance:buf_valid() then
     setup_terminal_events(term_instance, config)
     terminal = term_instance
+    vim.api.nvim_exec_autocmds("User", { pattern = "ClaudeCodeTerminalOpened", modeline = false })
   else
     terminal = nil
     local logger = require("claudecode.logger")
@@ -186,10 +188,12 @@ function M.simple_toggle(cmd_string, env_table, config)
     -- Terminal is visible, hide it
     logger.debug("terminal", "Simple toggle: hiding visible terminal")
     terminal:toggle()
+    vim.api.nvim_exec_autocmds("User", { pattern = "ClaudeCodeTerminalHidden", modeline = false })
   elseif terminal and terminal:buf_valid() and not terminal:win_valid() then
     -- Terminal exists but not visible, show it
     logger.debug("terminal", "Simple toggle: showing hidden terminal")
     terminal:toggle()
+    vim.api.nvim_exec_autocmds("User", { pattern = "ClaudeCodeTerminalOpened", modeline = false })
   else
     -- No terminal exists, create new one
     logger.debug("terminal", "Simple toggle: creating new terminal")
@@ -213,6 +217,7 @@ function M.focus_toggle(cmd_string, env_table, config)
   if terminal and terminal:buf_valid() and not terminal:win_valid() then
     logger.debug("terminal", "Focus toggle: showing hidden terminal")
     terminal:toggle()
+    vim.api.nvim_exec_autocmds("User", { pattern = "ClaudeCodeTerminalOpened", modeline = false })
   -- Terminal exists, is valid, and is visible
   elseif terminal and terminal:buf_valid() and terminal:win_valid() then
     local claude_term_neovim_win_id = terminal.win
@@ -222,6 +227,7 @@ function M.focus_toggle(cmd_string, env_table, config)
     if claude_term_neovim_win_id == current_neovim_win_id then
       logger.debug("terminal", "Focus toggle: hiding terminal (currently focused)")
       terminal:toggle()
+      vim.api.nvim_exec_autocmds("User", { pattern = "ClaudeCodeTerminalHidden", modeline = false })
     -- you're NOT in it
     else
       logger.debug("terminal", "Focus toggle: focusing terminal")


### PR DESCRIPTION
## Summary

Fires `doautocmd User <event>` at key plugin state transitions so configs and other plugins can react without poking at internals.

| Event | When |
|---|---|
| `ClaudeCodeDiffOpened` | A diff view is created (`_open_native_diff`) |
| `ClaudeCodeDiffClosed` | A diff is accepted (`_resolve_diff_as_saved`) or rejected (`_resolve_diff_as_rejected`) |
| `ClaudeCodeConnected` | A WebSocket client connects (`on_connect`) |
| `ClaudeCodeDisconnected` | A WebSocket client disconnects (`on_disconnect`) |
| `ClaudeCodeTerminalOpened` | Terminal window becomes visible (both snacks and native providers) |
| `ClaudeCodeTerminalHidden` | Terminal window is hidden (both snacks and native providers) |

## Usage

Auto-hide the terminal float when a diff opens, so the diff buffers aren't covered:

```lua
vim.api.nvim_create_autocmd("User", {
  pattern = "ClaudeCodeDiffOpened",
  callback = function()
    local term = require("claudecode.terminal")
    if term.get_active_terminal_bufnr() then
      term.simple_toggle()
    end
  end,
})
```

## Changes

- `lua/claudecode/diff.lua`: `ClaudeCodeDiffOpened` before returning from `_open_native_diff`; `ClaudeCodeDiffClosed` in both `_resolve_diff_as_saved` and `_resolve_diff_as_rejected`
- `lua/claudecode/server/init.lua`: `ClaudeCodeConnected` / `ClaudeCodeDisconnected` in the WebSocket callbacks, wrapped in `vim.schedule` since callbacks run off the main thread
- `lua/claudecode/terminal/snacks.lua`: `ClaudeCodeTerminalOpened` / `ClaudeCodeTerminalHidden` in `open`, `simple_toggle`, and `focus_toggle`
- `lua/claudecode/terminal/native.lua`: same events in `open_terminal`, `hide_terminal`, and `show_hidden_terminal`

Closes #222