### PR TITLE
feat: add option to disambiguate Neovim instances

### DIFF
--- a/lua/claudecode/config.lua
+++ b/lua/claudecode/config.lua
@@ -20,6 +20,7 @@ M.defaults = {
   connection_wait_delay = 600, -- Milliseconds to wait after connection before sending queued @ mentions
   connection_timeout = 10000, -- Maximum time to wait for Claude Code to connect (milliseconds)
   queue_timeout = 5000, -- Maximum time to keep @ mentions in queue (milliseconds)
+  ide_name_show_cwd = false, -- Append cwd basename to IDE name (e.g. "Neovim (project)")
   diff_opts = {
     layout = "vertical",
     open_in_new_tab = false, -- Open diff in a new tab (false = use current tab)

--- a/lua/claudecode/init.lua
+++ b/lua/claudecode/init.lua
@@ -441,7 +441,9 @@ function M.start(show_startup_notification)
   M.state.port = tonumber(result)
   M.state.auth_token = auth_token
 
-  local lock_success, lock_result, returned_auth_token = lockfile.create(M.state.port, auth_token)
+  local lock_success, lock_result, returned_auth_token = lockfile.create(M.state.port, auth_token, {
+    ide_name_show_cwd = M.state.config.ide_name_show_cwd,
+  })
 
   if not lock_success then
     server.stop()

--- a/lua/claudecode/lockfile.lua
+++ b/lua/claudecode/lockfile.lua
@@ -69,10 +69,11 @@ end
 ---Create the lock file for a specified WebSocket port
 ---@param port number The port number for the WebSocket server
 ---@param auth_token? string Optional pre-generated auth token (generates new one if not provided)
+---@param opts? {ide_name_show_cwd?: boolean} Optional settings
 ---@return boolean success Whether the operation was successful
 ---@return string result_or_error The lock file path if successful, or error message if failed
 ---@return string? auth_token The authentication token if successful
-function M.create(port, auth_token)
+function M.create(port, auth_token, opts)
   if not port or type(port) ~= "number" then
     return false, "Invalid port number"
   end
@@ -115,7 +116,9 @@ function M.create(port, auth_token)
   local lock_content = {
     pid = vim.fn.getpid(),
     workspaceFolders = workspace_folders,
-    ideName = "Neovim",
+    ideName = (opts and opts.ide_name_show_cwd)
+      and ("Neovim (" .. vim.fn.fnamemodify(vim.fn.getcwd(), ":t") .. ")")
+      or "Neovim",
     transport = "ws",
     authToken = auth_token,
   }
@@ -178,10 +181,11 @@ end
 
 ---Update the lock file for the given port
 ---@param port number The port number of the WebSocket server
+---@param opts? {ide_name_show_cwd?: boolean} Optional settings
 ---@return boolean success Whether the operation was successful
 ---@return string result_or_error The lock file path if successful, or error message if failed
 ---@return string? auth_token The authentication token if successful
-function M.update(port)
+function M.update(port, opts)
   if not port or type(port) ~= "number" then
     return false, "Invalid port number"
   end
@@ -194,7 +198,7 @@ function M.update(port)
     end
   end
 
-  return M.create(port)
+  return M.create(port, nil, opts)
 end
 
 ---Read the authentication token from a lock file

--- a/tests/lockfile_test.lua
+++ b/tests/lockfile_test.lua
@@ -397,4 +397,66 @@ describe("Lockfile Module", function()
       assert(error:find("Lock file does not exist"))
     end)
   end)
+
+  describe("ide_name_show_cwd option", function()
+    it("should use plain 'Neovim' by default", function()
+      local port = 12350
+      local success, lock_path = lockfile.create(port)
+      assert(success == true)
+
+      local file = io.open(lock_path, "r")
+      local content = file:read("*all")
+      file:close()
+      assert(content:find('"Neovim"'))
+      assert(not content:find("Neovim %("))
+
+      lockfile.remove(port)
+    end)
+
+    it("should use plain 'Neovim' when ide_name_show_cwd is false", function()
+      local port = 12351
+      local success, lock_path = lockfile.create(port, nil, { ide_name_show_cwd = false })
+      assert(success == true)
+
+      local file = io.open(lock_path, "r")
+      local content = file:read("*all")
+      file:close()
+      assert(content:find('"Neovim"'))
+      assert(not content:find("Neovim %("))
+
+      lockfile.remove(port)
+    end)
+
+    it("should append cwd basename when ide_name_show_cwd is true", function()
+      vim.fn.getcwd = function()
+        return "/home/user/my-project"
+      end
+      -- Mock fnamemodify to return the tail component
+      vim.fn.fnamemodify = function(_, modifier)
+        if modifier == ":t" then
+          return "my-project"
+        end
+        return _
+      end
+
+      local port = 12352
+      local success, lock_path = lockfile.create(port, nil, { ide_name_show_cwd = true })
+      assert(success == true)
+
+      local file = io.open(lock_path, "r")
+      local content = file:read("*all")
+      file:close()
+      assert(content:find("Neovim %(my%-project%)"))
+
+      lockfile.remove(port)
+
+      -- Restore mocks
+      vim.fn.getcwd = function()
+        return "/mock/cwd"
+      end
+      vim.fn.fnamemodify = function(fname, _)
+        return fname
+      end
+    end)
+  end)
 end)


### PR DESCRIPTION
## Why
When running multiple Neovim instances, `/ide` shows them all as "Neovim" making it hard to pick the right one.

### What
This adds an `ide_name_show_cwd` config option that appends the cwd basename to the IDE name, e.g. "Neovim (my-project)". Defaults to `false` to preserve existing behavior.

### Disclaimer on LLM usage
very much LLM generated as I am definitely not a lua expert. However, I reviewed the code and it looks quite reasonable :)