### PR TITLE
chore: add reviewfixer configs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,6 +34,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-go": {
+      "locked": {
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1747958103,
@@ -54,6 +70,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-go": "nixpkgs-go",
         "treefmt-nix": "treefmt-nix"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -34,7 +34,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-go": {
+    "nixpkgs-reviewfixer": {
       "locked": {
         "lastModified": 1776877367,
         "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
@@ -70,7 +70,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-go": "nixpkgs-go",
+        "nixpkgs-reviewfixer": "nixpkgs-reviewfixer",
         "treefmt-nix": "treefmt-nix"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,14 +3,21 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    # Separate, fresh nixpkgs pin used only to build reviewfixer, which
-    # requires Go >= 1.26.2 (newer than the main pin currently provides).
-    nixpkgs-go.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # Separate nixpkgs pin used only to build reviewfixer. The main pin is
+    # held back to avoid CI/formatter churn, but reviewfixer requires
+    # Go >= 1.26.2. Remove `nixpkgs-reviewfixer` (and `pkgsReviewfixer`
+    # below) once the main pin includes Go >= 1.26.2
+    # (check: `nix eval nixpkgs#go.version`).
+    #
+    # Note: `nix flake update` (no `--select`) bumps both inputs to the
+    # same rev, silently collapsing this version gap. Use
+    # `nix flake update nixpkgs-reviewfixer` to update this input alone.
+    nixpkgs-reviewfixer.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     treefmt-nix.url = "github:numtide/treefmt-nix";
   };
 
-  outputs = { self, nixpkgs, nixpkgs-go, flake-utils, treefmt-nix, ... }:
+  outputs = { self, nixpkgs, nixpkgs-reviewfixer, flake-utils, treefmt-nix, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
@@ -21,13 +28,13 @@
           ];
         };
 
-        pkgsGo = import nixpkgs-go { inherit system; };
+        pkgsReviewfixer = import nixpkgs-reviewfixer { inherit system; };
 
-        reviewfixer = pkgsGo.buildGoModule rec {
+        reviewfixer = pkgsReviewfixer.buildGoModule rec {
           pname = "reviewfixer";
           version = "0.1.0-beta.0";
 
-          src = pkgsGo.fetchFromGitHub {
+          src = pkgsReviewfixer.fetchFromGitHub {
             owner = "ThomasK33";
             repo = "reviewfixer";
             rev = "v${version}";
@@ -40,7 +47,7 @@
           # Nix build sandbox. Skip the test phase here.
           doCheck = false;
 
-          meta = with pkgsGo.lib; {
+          meta = with pkgsReviewfixer.lib; {
             description = "Local harness for working through review feedback on Graphite-managed stacked PRs";
             homepage = "https://github.com/ThomasK33/reviewfixer";
             license = licenses.mit;

--- a/flake.nix
+++ b/flake.nix
@@ -3,11 +3,14 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # Separate, fresh nixpkgs pin used only to build reviewfixer, which
+    # requires Go >= 1.26.2 (newer than the main pin currently provides).
+    nixpkgs-go.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     treefmt-nix.url = "github:numtide/treefmt-nix";
   };
 
-  outputs = { self, nixpkgs, flake-utils, treefmt-nix, ... }:
+  outputs = { self, nixpkgs, nixpkgs-go, flake-utils, treefmt-nix, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
@@ -16,6 +19,33 @@
           config.allowUnfreePredicate = pkg: builtins.elem (pkgs.lib.getName pkg) [
             "claude-code"
           ];
+        };
+
+        pkgsGo = import nixpkgs-go { inherit system; };
+
+        reviewfixer = pkgsGo.buildGoModule rec {
+          pname = "reviewfixer";
+          version = "0.1.0-beta.0";
+
+          src = pkgsGo.fetchFromGitHub {
+            owner = "ThomasK33";
+            repo = "reviewfixer";
+            rev = "v${version}";
+            hash = "sha256-hrnSm7ttpyUAtkre9micI2n9smKgzX5AmUcj3bJQjbU=";
+          };
+
+          vendorHash = "sha256-yIWbmHFxmOeXBm5TMRsupy33DC6VAUYvZNSz5wa1yxA=";
+
+          # Upstream tests shell out to `git`, which isn't available in the
+          # Nix build sandbox. Skip the test phase here.
+          doCheck = false;
+
+          meta = with pkgsGo.lib; {
+            description = "Local harness for working through review feedback on Graphite-managed stacked PRs";
+            homepage = "https://github.com/ThomasK33/reviewfixer";
+            license = licenses.mit;
+            mainProgram = "reviewfixer";
+          };
         };
 
         treefmt = treefmt-nix.lib.evalModule pkgs {
@@ -56,6 +86,7 @@
           websocat
           jq
           fzf
+          reviewfixer
           # claude-code
         ];
       in

--- a/reviewfixer.yaml
+++ b/reviewfixer.yaml
@@ -1,9 +1,11 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/ThomasK33/reviewfixer/refs/heads/main/reviewfixer.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ThomasK33/reviewfixer/v0.1.0-beta.0/reviewfixer.schema.json
 # Config for running reviewfixer against the Claude ACP adapter.
 # reviewfixer automatically addresses PR review findings using an AI agent.
 #
 # Prerequisites:
-# - `reviewfixer` CLI installed (`go install github.com/ThomasK33/reviewfixer@latest`,
+# - Use the project's Nix devShell (`nix develop` or `direnv allow`) which
+#   already includes `reviewfixer`; this is the primary dev path here, or
+# - `reviewfixer` CLI installed (`go install github.com/ThomasK33/reviewfixer@v0.1.0-beta.0`,
 #   or download a binary from https://github.com/ThomasK33/reviewfixer/releases)
 # - `node` and `npm`/`npx` available on PATH (for the ACP adapter below)
 # - `ANTHROPIC_API_KEY` exported in the shell that launches reviewfixer

--- a/reviewfixer.yaml
+++ b/reviewfixer.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ThomasK33/reviewfixer/refs/heads/main/reviewfixer.schema.json
+# Config for running reviewfixer against the Claude ACP adapter.
+#
+# Prerequisites:
+# - `node` and `npm`/`npx` available on PATH
+# - `ANTHROPIC_API_KEY` exported in the shell that launches reviewfixer
+#
+# Usage:
+#   reviewfixer validate --config ./reviewfixer.yaml
+#   reviewfixer --config ./reviewfixer.yaml
+#   reviewfixer run --config ./reviewfixer.yaml
+#
+# If you install the adapter globally instead of using `npx`, you can replace:
+#   command: npx
+#   args: ["-y", "@agentclientprotocol/claude-agent-acp"]
+# with:
+#   command: claude-agent-acp
+
+runtime:
+  kind: acp
+  compact_on_resume: true
+  acp:
+    command: npx
+    args:
+      - -y
+      - "@agentclientprotocol/claude-agent-acp"
+
+review:
+  request:
+    - mode: comment
+      comment: "/coder-agents-review"

--- a/reviewfixer.yaml
+++ b/reviewfixer.yaml
@@ -1,8 +1,11 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/ThomasK33/reviewfixer/refs/heads/main/reviewfixer.schema.json
 # Config for running reviewfixer against the Claude ACP adapter.
+# reviewfixer automatically addresses PR review findings using an AI agent.
 #
 # Prerequisites:
-# - `node` and `npm`/`npx` available on PATH
+# - `reviewfixer` CLI installed (`go install github.com/ThomasK33/reviewfixer@latest`,
+#   or download a binary from https://github.com/ThomasK33/reviewfixer/releases)
+# - `node` and `npm`/`npx` available on PATH (for the ACP adapter below)
 # - `ANTHROPIC_API_KEY` exported in the shell that launches reviewfixer
 #
 # Usage:
@@ -12,7 +15,7 @@
 #
 # If you install the adapter globally instead of using `npx`, you can replace:
 #   command: npx
-#   args: ["-y", "@agentclientprotocol/claude-agent-acp"]
+#   args: ["-y", "@agentclientprotocol/claude-agent-acp@0.31.1"]
 # with:
 #   command: claude-agent-acp
 
@@ -23,9 +26,13 @@ runtime:
     command: npx
     args:
       - -y
-      - "@agentclientprotocol/claude-agent-acp"
+      # Pinned to avoid pulling an unverified `latest` at invocation time;
+      # bump deliberately after reviewing release notes.
+      - "@agentclientprotocol/claude-agent-acp@0.31.1"
 
 review:
   request:
+    # `/coder-agents-review` is consumed by the external coder-agents-review
+    # bot (not by any workflow in this repository).
     - mode: comment
       comment: "/coder-agents-review"


### PR DESCRIPTION
## Add reviewfixer to devShell with dedicated nixpkgs pin

Introduces `reviewfixer.yaml` at the repository root to configure reviewfixer to run against the Claude ACP adapter via `npx @agentclientprotocol/claude-agent-acp`. After a successful fixing turn, it automatically posts a `/coder-agents-review` comment to request re-review.

Adds `reviewfixer` to the Nix devShell by building it from a separate `nixpkgs-reviewfixer` input pinned to `nixos-unstable`. This separate pin is necessary because `reviewfixer` requires Go >= 1.26.2, which is not yet available in the main `nixpkgs` pin. The separate input should be removed once the main pin includes Go >= 1.26.2. Note that running `nix flake update` without `--select` will silently collapse both pins to the same revision; use `nix flake update nixpkgs-reviewfixer` to update only that input.

Upstream tests are skipped in the Nix build because they shell out to `git`, which is unavailable in the Nix build sandbox.