### PR TITLE
Add context to ide names

### DIFF
--- a/lua/claudecode/config.lua
+++ b/lua/claudecode/config.lua
@@ -34,6 +34,10 @@ M.defaults = {
     { name = "Claude Haiku 4.5 (Latest)", value = "haiku" },
   },
   terminal = nil, -- Will be lazy-loaded to avoid circular dependency
+  ide_name = {
+    override = nil,
+    tmux_include_pane = false,
+  },
 }
 
 ---Validates the provided configuration table.
@@ -154,6 +158,16 @@ function M.validate(config)
   end
   if config.diff_opts.open_in_current_tab ~= nil then
     assert(type(config.diff_opts.open_in_current_tab) == "boolean", "diff_opts.open_in_current_tab must be a boolean")
+  end
+
+  if config.ide_name ~= nil then
+    assert(type(config.ide_name) == "table", "ide_name must be a table")
+    if config.ide_name.override ~= nil then
+      assert(type(config.ide_name.override) == "string", "ide_name.override must be a string")
+    end
+    if config.ide_name.tmux_include_pane ~= nil then
+      assert(type(config.ide_name.tmux_include_pane) == "boolean", "ide_name.tmux_include_pane must be a boolean")
+    end
   end
 
   -- Validate env

--- a/lua/claudecode/init.lua
+++ b/lua/claudecode/init.lua
@@ -441,7 +441,8 @@ function M.start(show_startup_notification)
   M.state.port = tonumber(result)
   M.state.auth_token = auth_token
 
-  local lock_success, lock_result, returned_auth_token = lockfile.create(M.state.port, auth_token)
+  local lock_success, lock_result, returned_auth_token =
+    lockfile.create(M.state.port, auth_token, M.state.config.ide_name)
 
   if not lock_success then
     server.stop()

--- a/lua/claudecode/lockfile.lua
+++ b/lua/claudecode/lockfile.lua
@@ -60,6 +60,39 @@ local function generate_auth_token()
   return uuid
 end
 
+---Build the ideName label shown in the /ide session picker.
+---@param ide_name_config table The ide_name subtable from ClaudeCodeConfig
+---@return string label e.g. "Neovim [tmux:mysession:mywindow]"
+local function build_ide_name(ide_name_config)
+  local cfg = ide_name_config or {}
+
+  if cfg.override and cfg.override ~= "" then
+    return cfg.override
+  end
+
+  local context
+
+  local tmux = os.getenv("TMUX")
+  if tmux and tmux ~= "" then
+    local session = vim.fn.system("tmux display-message -p '#S'"):gsub("%s+$", "")
+    local window = vim.fn.system("tmux display-message -p '#W'"):gsub("%s+$", "")
+    context = "tmux:" .. session .. ":" .. window
+    if cfg.tmux_include_pane then
+      local pane = vim.fn.system("tmux display-message -p '#P'"):gsub("%s+$", "")
+      context = context .. ":" .. pane
+    end
+  else
+    local cwd = vim.fn.getcwd()
+    local home = os.getenv("HOME") or ""
+    if home ~= "" and cwd:sub(1, #home) == home then
+      cwd = "~" .. cwd:sub(#home + 1)
+    end
+    context = cwd
+  end
+
+  return "Neovim [" .. context .. "]"
+end
+
 ---Generate a new authentication token
 ---@return string auth_token A newly generated authentication token
 function M.generate_auth_token()
@@ -69,10 +102,11 @@ end
 ---Create the lock file for a specified WebSocket port
 ---@param port number The port number for the WebSocket server
 ---@param auth_token? string Optional pre-generated auth token (generates new one if not provided)
+---@param ide_name_config? table Optional ide_name subtable from ClaudeCodeConfig
 ---@return boolean success Whether the operation was successful
 ---@return string result_or_error The lock file path if successful, or error message if failed
 ---@return string? auth_token The authentication token if successful
-function M.create(port, auth_token)
+function M.create(port, auth_token, ide_name_config)
   if not port or type(port) ~= "number" then
     return false, "Invalid port number"
   end
@@ -115,7 +149,7 @@ function M.create(port, auth_token)
   local lock_content = {
     pid = vim.fn.getpid(),
     workspaceFolders = workspace_folders,
-    ideName = "Neovim",
+    ideName = build_ide_name(ide_name_config),
     transport = "ws",
     authToken = auth_token,
   }
@@ -178,10 +212,11 @@ end
 
 ---Update the lock file for the given port
 ---@param port number The port number of the WebSocket server
+---@param ide_name_config? table Optional ide_name subtable from ClaudeCodeConfig
 ---@return boolean success Whether the operation was successful
 ---@return string result_or_error The lock file path if successful, or error message if failed
 ---@return string? auth_token The authentication token if successful
-function M.update(port)
+function M.update(port, ide_name_config)
   if not port or type(port) ~= "number" then
     return false, "Invalid port number"
   end
@@ -194,7 +229,7 @@ function M.update(port)
     end
   end
 
-  return M.create(port)
+  return M.create(port, nil, ide_name_config)
 end
 
 ---Read the authentication token from a lock file

--- a/tests/lockfile_test.lua
+++ b/tests/lockfile_test.lua
@@ -397,4 +397,170 @@ describe("Lockfile Module", function()
       assert(error:find("Lock file does not exist"))
     end)
   end)
+
+  describe("build_ide_name (via lockfile.create)", function()
+    local orig_getenv
+    local orig_system
+    local orig_getcwd
+
+    local function get_ide_name_from_lock(port)
+      local temp_dir = os.getenv("TMPDIR") or "/tmp"
+      local lock_path = temp_dir .. "/claude_test/.claude/ide/" .. port .. ".lock"
+      local f = io.open(lock_path, "r")
+      if not f then
+        return nil
+      end
+      local content = f:read("*a")
+      f:close()
+      return content:match('"ideName"%s*:%s*"([^"]*)"')
+    end
+
+    before_each(function()
+      orig_getenv = os.getenv
+      orig_system = vim.fn.system
+      orig_getcwd = vim.fn.getcwd
+    end)
+
+    after_each(function()
+      os.getenv = orig_getenv
+      vim.fn.system = orig_system
+      vim.fn.getcwd = orig_getcwd
+    end)
+
+    it("should use override when provided", function()
+      os.getenv = function(key)
+        if key == "TMUX" then
+          return nil
+        end
+        return orig_getenv(key)
+      end
+
+      local success = lockfile.create(23001, "test-token-override-123", { override = "My Custom Label" })
+      assert(success == true)
+      assert("My Custom Label" == get_ide_name_from_lock(23001))
+    end)
+
+    it("should fall through to cwd when override is empty string", function()
+      os.getenv = function(key)
+        if key == "TMUX" then
+          return nil
+        end
+        if key == "HOME" then
+          return "/home/testuser"
+        end
+        return orig_getenv(key)
+      end
+      vim.fn.getcwd = function()
+        return "/home/testuser/projects/myproject"
+      end
+
+      local success = lockfile.create(23002, "test-token-empty-override-12", { override = "" })
+      assert(success == true)
+      assert("Neovim [~/projects/myproject]" == get_ide_name_from_lock(23002))
+    end)
+
+    it("should abbreviate HOME in cwd when not in tmux", function()
+      os.getenv = function(key)
+        if key == "TMUX" then
+          return nil
+        end
+        if key == "HOME" then
+          return "/home/testuser"
+        end
+        return orig_getenv(key)
+      end
+      vim.fn.getcwd = function()
+        return "/home/testuser/code/myrepo"
+      end
+
+      local success = lockfile.create(23003, "test-token-cwd-abbrev-12345", {})
+      assert(success == true)
+      assert("Neovim [~/code/myrepo]" == get_ide_name_from_lock(23003))
+    end)
+
+    it("should use full cwd when not under HOME", function()
+      os.getenv = function(key)
+        if key == "TMUX" then
+          return nil
+        end
+        if key == "HOME" then
+          return "/home/testuser"
+        end
+        return orig_getenv(key)
+      end
+      vim.fn.getcwd = function()
+        return "/opt/projects/myrepo"
+      end
+
+      local success = lockfile.create(23004, "test-token-cwd-full-1234567", {})
+      assert(success == true)
+      assert("Neovim [/opt/projects/myrepo]" == get_ide_name_from_lock(23004))
+    end)
+
+    it("should include tmux session and window when inside tmux", function()
+      os.getenv = function(key)
+        if key == "TMUX" then
+          return "/tmp/tmux-1000/default,12345,0"
+        end
+        return orig_getenv(key)
+      end
+      vim.fn.system = function(cmd)
+        if cmd:find("#S") then
+          return "work\n"
+        end
+        if cmd:find("#W") then
+          return "editor\n"
+        end
+        return ""
+      end
+
+      local success = lockfile.create(23005, "test-token-tmux-no-pane-123", { tmux_include_pane = false })
+      assert(success == true)
+      assert("Neovim [tmux:work:editor]" == get_ide_name_from_lock(23005))
+    end)
+
+    it("should include pane index when tmux_include_pane is true", function()
+      os.getenv = function(key)
+        if key == "TMUX" then
+          return "/tmp/tmux-1000/default,12345,0"
+        end
+        return orig_getenv(key)
+      end
+      vim.fn.system = function(cmd)
+        if cmd:find("#S") then
+          return "work\n"
+        end
+        if cmd:find("#W") then
+          return "editor\n"
+        end
+        if cmd:find("#P") then
+          return "2\n"
+        end
+        return ""
+      end
+
+      local success = lockfile.create(23006, "test-token-tmux-with-pane-12", { tmux_include_pane = true })
+      assert(success == true)
+      assert("Neovim [tmux:work:editor:2]" == get_ide_name_from_lock(23006))
+    end)
+
+    it("should default to cwd label when ide_name_config is nil", function()
+      os.getenv = function(key)
+        if key == "TMUX" then
+          return nil
+        end
+        if key == "HOME" then
+          return "/home/testuser"
+        end
+        return orig_getenv(key)
+      end
+      vim.fn.getcwd = function()
+        return "/home/testuser/work"
+      end
+
+      local success = lockfile.create(23007, "test-token-nil-config-12345", nil)
+      assert(success == true)
+      assert("Neovim [~/work]" == get_ide_name_from_lock(23007))
+    end)
+  end)
 end)

--- a/tests/unit/config_spec.lua
+++ b/tests/unit/config_spec.lua
@@ -263,6 +263,140 @@ describe("Configuration", function()
     expect(success).to_be_true()
   end)
 
+  it("should have ide_name in defaults with correct values", function()
+    expect(config.defaults).to_have_key("ide_name")
+    expect(config.defaults.ide_name).to_be_table()
+    expect(config.defaults.ide_name.override).to_be_nil()
+    expect(config.defaults.ide_name.tmux_include_pane).to_be_false()
+  end)
+
+  it("should accept valid ide_name with override string", function()
+    local user_config = {
+      port_range = { min = 10000, max = 65535 },
+      auto_start = true,
+      log_level = "info",
+      track_selection = true,
+      visual_demotion_delay_ms = 50,
+      connection_wait_delay = 200,
+      connection_timeout = 10000,
+      queue_timeout = 5000,
+      diff_opts = { layout = "vertical", open_in_new_tab = false, keep_terminal_focus = false },
+      env = {},
+      models = { { name = "Test Model", value = "test" } },
+      ide_name = { override = "My Neovim", tmux_include_pane = true },
+    }
+
+    local success, _ = pcall(function()
+      config.validate(user_config)
+    end)
+
+    expect(success).to_be_true()
+  end)
+
+  it("should accept ide_name with only tmux_include_pane set", function()
+    local user_config = {
+      port_range = { min = 10000, max = 65535 },
+      auto_start = true,
+      log_level = "info",
+      track_selection = true,
+      visual_demotion_delay_ms = 50,
+      connection_wait_delay = 200,
+      connection_timeout = 10000,
+      queue_timeout = 5000,
+      diff_opts = { layout = "vertical", open_in_new_tab = false, keep_terminal_focus = false },
+      env = {},
+      models = { { name = "Test Model", value = "test" } },
+      ide_name = { tmux_include_pane = true },
+    }
+
+    local success, _ = pcall(function()
+      config.validate(user_config)
+    end)
+
+    expect(success).to_be_true()
+  end)
+
+  it("should reject ide_name that is not a table", function()
+    local invalid_config = {
+      port_range = { min = 10000, max = 65535 },
+      auto_start = true,
+      log_level = "info",
+      track_selection = true,
+      visual_demotion_delay_ms = 50,
+      connection_wait_delay = 200,
+      connection_timeout = 10000,
+      queue_timeout = 5000,
+      diff_opts = { layout = "vertical", open_in_new_tab = false, keep_terminal_focus = false },
+      env = {},
+      models = { { name = "Test Model", value = "test" } },
+      ide_name = "Neovim",
+    }
+
+    local success, _ = pcall(function()
+      config.validate(invalid_config)
+    end)
+
+    expect(success).to_be_false()
+  end)
+
+  it("should reject non-string ide_name.override", function()
+    local invalid_config = {
+      port_range = { min = 10000, max = 65535 },
+      auto_start = true,
+      log_level = "info",
+      track_selection = true,
+      visual_demotion_delay_ms = 50,
+      connection_wait_delay = 200,
+      connection_timeout = 10000,
+      queue_timeout = 5000,
+      diff_opts = { layout = "vertical", open_in_new_tab = false, keep_terminal_focus = false },
+      env = {},
+      models = { { name = "Test Model", value = "test" } },
+      ide_name = { override = 123 },
+    }
+
+    local success, _ = pcall(function()
+      config.validate(invalid_config)
+    end)
+
+    expect(success).to_be_false()
+  end)
+
+  it("should reject non-boolean ide_name.tmux_include_pane", function()
+    local invalid_config = {
+      port_range = { min = 10000, max = 65535 },
+      auto_start = true,
+      log_level = "info",
+      track_selection = true,
+      visual_demotion_delay_ms = 50,
+      connection_wait_delay = 200,
+      connection_timeout = 10000,
+      queue_timeout = 5000,
+      diff_opts = { layout = "vertical", open_in_new_tab = false, keep_terminal_focus = false },
+      env = {},
+      models = { { name = "Test Model", value = "test" } },
+      ide_name = { tmux_include_pane = "yes" },
+    }
+
+    local success, _ = pcall(function()
+      config.validate(invalid_config)
+    end)
+
+    expect(success).to_be_false()
+  end)
+
+  it("should merge ide_name from user config with defaults", function()
+    local user_config = {
+      auto_start = false,
+      ide_name = { tmux_include_pane = true },
+    }
+
+    local merged = config.apply(user_config)
+
+    expect(merged.ide_name).to_be_table()
+    expect(merged.ide_name.tmux_include_pane).to_be_true()
+  end)
+
   it("should reject invalid type for external_terminal_cmd", function()
     local invalid_config = {
       port_range = { min = 10000, max = 65535 },


### PR DESCRIPTION
<img width="866" height="119" alt="image" src="https://github.com/user-attachments/assets/3b039baa-b33b-491d-ada2-3dad34335573" />
Allows working with several pairs of neovim + claude code cli sessions in parallel, especially useful for old school chaps like me who like 

```lua
terminal = {
  provider = "none", -- no UI actions; server + tools remain available
}
```