### PR TITLE
feat: add ClaudeCodeAgents command to support muti agents in a single view

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ When Anthropic released Claude Code, they only supported VS Code and JetBrains. 
     { "<leader>ar", "<cmd>ClaudeCode --resume<cr>", desc = "Resume Claude" },
     { "<leader>aC", "<cmd>ClaudeCode --continue<cr>", desc = "Continue Claude" },
     { "<leader>am", "<cmd>ClaudeCodeSelectModel<cr>", desc = "Select Claude model" },
+    { "<leader>ag", "<cmd>ClaudeCodeAgents<cr>", desc = "Claude Agents" },
     { "<leader>ab", "<cmd>ClaudeCodeAdd %<cr>", desc = "Add current buffer" },
     { "<leader>as", "<cmd>ClaudeCodeSend<cr>", mode = "v", desc = "Send to Claude" },
     {
@@ -194,6 +195,7 @@ Configure the plugin with the detected path:
 - `:ClaudeCode` - Toggle the Claude Code terminal window
 - `:ClaudeCodeFocus` - Smart focus/toggle Claude terminal
 - `:ClaudeCodeSelectModel` - Select Claude model and open terminal with optional arguments
+- `:ClaudeCodeAgents [args]` - Toggle Claude Agents terminal (runs `claude agents`); accepts extra flags, e.g. `:ClaudeCodeAgents --permission-mode auto`
 - `:ClaudeCodeSend` - Send current visual selection to Claude
 - `:ClaudeCodeAdd <file-path> [start-line] [end-line]` - Add specific file to Claude context with optional line range
 - `:ClaudeCodeDiffAccept` - Accept diff changes

--- a/lua/claudecode/init.lua
+++ b/lua/claudecode/init.lua
@@ -1015,6 +1015,18 @@ function M._create_commands()
       desc = "Open the Claude Code terminal window with optional arguments",
     })
 
+    vim.api.nvim_create_user_command("ClaudeCodeAgents", function(opts)
+      local current_mode = vim.fn.mode()
+      if current_mode == "v" or current_mode == "V" or current_mode == "\22" then
+        vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "n", false)
+      end
+      local extra = opts.args and opts.args ~= "" and (" " .. opts.args) or ""
+      terminal.simple_toggle({}, "agents" .. extra)
+    end, {
+      nargs = "*",
+      desc = "Toggle the Claude Code Agents terminal window with optional arguments",
+    })
+
     vim.api.nvim_create_user_command("ClaudeCodeClose", function()
       terminal.close()
     end, {
@@ -1023,7 +1035,7 @@ function M._create_commands()
   else
     logger.error(
       "init",
-      "Terminal module not found. Terminal commands (ClaudeCode, ClaudeCodeOpen, ClaudeCodeClose) not registered."
+      "Terminal module not found. Terminal commands (ClaudeCode, ClaudeCodeOpen, ClaudeCodeAgents, ClaudeCodeClose) not registered."
     )
   end
 


### PR DESCRIPTION
`claude agents` is a brand new command to open up [`Agent View`](https://code.claude.com/docs/en/agent-view). This enables us to manage multiple sessions at once. Without having to create and support multiple panes in neovim, this will let users manage multiple sessions at once. 