### PR TITLE
fix(terminal): work around Neovim <0.12.2 terminal paste fragmentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Bug Fixes
+
+- Work around a Neovim core bug (< 0.12.2) that fragmented large bracketed pastes into the terminal across `vim.paste` phases, making Cmd+V appear to truncate content. Added a scoped, version-gated `vim.paste` shim controlled by `terminal.fix_streamed_paste` (`"auto"` by default; no-op on Neovim >= 0.12.2). ([#161](https://github.com/coder/claudecode.nvim/issues/161))
+
 ## [0.3.0] - 2025-09-15
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -264,6 +264,10 @@ For deep technical details, see [ARCHITECTURE.md](./ARCHITECTURE.md).
       provider = "auto", -- "auto", "snacks", "native", "external", "none", or custom provider table
       auto_close = true,
       snacks_win_opts = {}, -- Opts to pass to `Snacks.terminal.open()` - see Floating Window section below
+      -- Work around a Neovim core bug (< 0.12.2) that fragments large pastes into
+      -- the terminal, making Cmd+V appear to truncate ([#161]). true | false | "auto"
+      -- ("auto", the default, enables it only on affected Neovim versions).
+      fix_streamed_paste = "auto",
 
       -- Provider-specific options
       provider_opts = {

--- a/fixtures/paste-repro/README.md
+++ b/fixtures/paste-repro/README.md
@@ -1,0 +1,147 @@
+# paste-repro — triage & reproduction for issue #161
+
+**Issue:** [#161](https://github.com/coder/claudecode.nvim/issues/161) — "Pasting text with
+Cmd+V in the Claude Code terminal truncates content, while right-click paste works."
+
+## TL;DR verdict
+
+This is **not a claudecode.nvim bug**. It is an upstream **Neovim core** bug in the default
+terminal paste path ([neovim/neovim#39110](https://github.com/neovim/neovim/issues/39110)),
+fixed by [PR #39152](https://github.com/neovim/neovim/pull/39152) (milestone **0.12.2**) and
+backport #39174. The plugin never touches the paste path, so it inherits whatever the running
+Neovim build does.
+
+A large bracketed paste into a `:terminal` buffer is streamed through `vim.paste(lines, phase)`
+in phases (1→2→…→3). On **affected builds**, each streamed phase is independently wrapped in its
+own `ESC[200~ … ESC[201~` bracketed-paste markers, so one logical paste reaches the inner program
+(Claude) as **N separate paste events**. Claude renders N `[Pasted text #k]` placeholders with
+phase-boundary characters leaking between them — which the user perceives as truncation.
+
+| Neovim build                 | bracketed-paste segments seen by inner PTY | verdict         |
+| ---------------------------- | ------------------------------------------ | --------------- |
+| 0.11.5 (reporter's version)  | **6**                                      | 🐛 fragmented   |
+| 0.11.6 (commenter's version) | **6**                                      | 🐛 fragmented   |
+| 0.12.2 (fix present)         | **1**                                      | ✅ single paste |
+| 0.11.6 + workaround          | **1**                                      | ✅ single paste |
+
+(Counts are for a 120-line / ~6 KB payload; the number of segments scales with paste size.)
+
+## Why it is size/timing dependent
+
+The fragmentation is driven by **TUI input read chunking** (~1 KB reads). A paste small enough to
+land in a single read arrives as one non-streamed `phase == -1` call → one segment → no bug.
+A larger paste spans multiple reads → streamed phases 1/2/…/3 → on an affected build, one segment
+per phase. This is why short pastes look fine and large pastes "truncate", and why there is no
+fixed line threshold.
+
+## Root-cause chain (verified)
+
+1. Emulator (WezTerm/Ghostty/iTerm2) wraps the clipboard in `ESC[200~ … ESC[201~` and writes it
+   to Neovim's PTY as one logical paste.
+2. Neovim's TUI streams it through `vim.paste(lines, phase)` — `runtime/lua/vim/_core/editor.lua`
+   (historically `runtime/lua/vim/_editor.lua`). For a terminal buffer the handler runs
+   `nvim_put(lines, 'c', false, true)` **once per phase** (editor.lua:185-186).
+3. Each `nvim_put` → C `do_put` (`register.c`) → `terminal_paste` (`terminal.c`), which wraps the
+   write in bracketed-paste markers **iff** the inner program enabled DECSET 2004.
+4. **The defect:** before #39152, `terminal_paste` emitted start/end markers _unconditionally on
+   every call_, so N phases ⇒ N bracketed segments. The fix added a `streamed_paste` flag (managed
+   across phases by `nvim_paste` in `api/vim.c`) so the whole stream gets exactly one marker pair.
+   The fix is at the **C layer**; the Lua `vim.paste` in 0.12.2 still does a per-phase `nvim_put`.
+
+`claudecode.nvim` does **not** override `vim.paste`, set paste keymaps, or call
+`nvim_chan_send`/`nvim_paste` (native.lua uses plain `vim.fn.termopen`; snacks.lua delegates to
+`Snacks.terminal.open`). It neither causes nor currently mitigates the bug.
+
+### Why right-click may differ from Cmd+V (unverified)
+
+Plausibly, right-click paste in some emulators injects clipboard bytes **directly into the inner
+PTY**, bypassing Neovim's `vim.paste` streaming entirely, so it arrives as one clean bracketed
+paste. Cmd+V is intercepted by the TUI and routed through the streamed phases. This is
+emulator-/keybinding-dependent and was not confirmed in a controlled test.
+
+## How this fixture proves it
+
+`claude` requires auth and hides its paste handling, so this fixture replaces it with
+[`observer.py`](./observer.py): a tiny program that enables bracketed paste (DECSET 2004) and logs
+exactly how many `ESC[200~`/`ESC[201~` segments the inner PTY receives. **Segment count is the
+signal** (`start_markers`/`end_markers` in the log's `TOTAL` line): `>1` = bug, `1` = correct.
+The observer is wired in as `terminal_cmd`, so pastes flow through the _real_ plugin terminal path.
+
+## Reproduce it
+
+The bug only appears on an affected Neovim. Install one with mise:
+
+```bash
+mise install neovim@0.11.6      # affected (also 0.11.5, 0.12.1)
+```
+
+### A. Automated (agent-tty) — deterministic, no manual steps
+
+From the repo root:
+
+```bash
+NVIM_BIN="$HOME/.local/share/mise/installs/neovim/0.11.6/bin/nvim" \
+  fixtures/paste-repro/agent-repro.sh
+```
+
+Expected on 0.11.6:
+
+```
+  default            TOTAL ... start_markers=6 end_markers=6  => BUG (fragmented)
+  with-workaround    TOTAL ... start_markers=1 end_markers=1  => OK (single paste)
+```
+
+Re-run with a 0.12.2 `NVIM_BIN` and both rows report `OK` — demonstrating the version fix.
+The script drives a real Neovim TUI in an isolated agent-tty session, auto-opens the plugin's
+Claude terminal (`PASTE_REPRO_AUTOOPEN=1`), pastes via bracketed paste, and reports segments.
+
+### B. Manual (interactive)
+
+```bash
+source fixtures/nvim-aliases.sh
+PATH="$HOME/.local/share/mise/installs/neovim/0.11.6/bin:$PATH" vv paste-repro
+```
+
+Then inside Neovim:
+
+1. `<leader>ac` opens the Claude terminal (running `observer.py`); you'll see `OBSERVER READY`.
+2. Copy 100+ lines to the system clipboard and paste with **Cmd+V** (bracketed paste).
+3. Inspect the observer log (path shown by `<leader>al`, default
+   `:echo stdpath('cache')`/`claudecode-paste-observer.log`): a `start_markers` > 1 in the `TOTAL`
+   line is the bug. Set `APPLY_PASTE_FIX=1` before launching to verify the workaround collapses it
+   to 1.
+
+### C. Pure-Neovim isolation (no plugin) — proves it's core, not the plugin
+
+```bash
+NVIM=$HOME/.local/share/mise/installs/neovim/0.11.6/bin/nvim
+$NVIM --clean -c "terminal python3 $PWD/fixtures/paste-repro/observer.py /tmp/obs.log" -c startinsert
+# paste 100+ lines, then: grep TOTAL /tmp/obs.log   -> start_markers=6 on 0.11.6, =1 on 0.12.2
+```
+
+## The workaround (and its edge cases)
+
+The community workaround (huiyu + kyleawayan, in the issue thread) overrides `vim.paste` for
+terminal buffers to coalesce streamed phases into a single `phase == -1` replay (toggle in this
+fixture with `APPLY_PASTE_FIX=1`):
+
+- Coalescing to `phase == -1` → one `nvim_put` → one bracketed segment → one `[Pasted text]`.
+- kyleawayan's refinement re-glues the mid-line chunk seam
+  (`chunks[#chunks] = chunks[#chunks] .. lines[1]`); without it, every chunk boundary injects a
+  spurious newline (because `lines` is a `readfile()`-style split with delimiters dropped).
+- **Residual edge case** (flagged for the fix phase, not verified here): a chunk boundary landing
+  exactly on a source newline could drop a legitimate newline. Worth a targeted test before
+  shipping.
+
+## Recommendation
+
+- **Real fix:** upgrade Neovim to **0.12.2+**.
+- **Mitigation for users on 0.11.x / 0.12.1:** ship the coalescing `vim.paste` override behind a
+  config flag (e.g. `terminal.fix_streamed_paste`), scoped to `buftype == 'terminal'`.
+
+## Files
+
+- `init.lua` — fixture config (native provider; `terminal_cmd` → observer; `APPLY_PASTE_FIX`,
+  `PASTE_REPRO_AUTOOPEN`, `PASTE_OBSERVER_LOG` env toggles).
+- `observer.py` — bracketed-paste segment counter (the measurement instrument).
+- `agent-repro.sh` — self-contained automated reproduction via agent-tty.

--- a/fixtures/paste-repro/README.md
+++ b/fixtures/paste-repro/README.md
@@ -69,37 +69,43 @@ The observer is wired in as `terminal_cmd`, so pastes flow through the _real_ pl
 
 ## Reproduce it
 
-The bug only appears on an affected Neovim. Install one with mise:
-
-```bash
-mise install neovim@0.11.6      # affected (also 0.11.5, 0.12.1)
-```
+The bug only appears on an affected Neovim (`< 0.12.2`). You do **not** need to change your
+installed/active Neovim — `mise exec neovim@<ver> -- nvim …` runs an old build ephemerally. mise
+keeps versions side-by-side in its own cache and only switches the active one via `mise use`, so
+this never touches your default Neovim. (`mise exec neovim@<ver> -- nvim` resolves the managed tool
+directly, so it also isn't shadowed by other version managers on your `PATH`.) `agent-repro.sh`
+does this for you via `NVIM_VERSION`.
 
 ### A. Automated (agent-tty) — deterministic, no manual steps
 
 From the repo root:
 
 ```bash
-NVIM_BIN="$HOME/.local/share/mise/installs/neovim/0.11.6/bin/nvim" \
-  fixtures/paste-repro/agent-repro.sh
+NVIM_VERSION=0.11.7 fixtures/paste-repro/agent-repro.sh   # affected: also 0.11.5/0.11.6/0.12.0/0.12.1
 ```
 
-Expected on 0.11.6:
+Expected on an affected version:
 
 ```
   default            TOTAL ... start_markers=6 end_markers=6  => BUG (fragmented)
   with-workaround    TOTAL ... start_markers=1 end_markers=1  => OK (single paste)
 ```
 
-Re-run with a 0.12.2 `NVIM_BIN` and both rows report `OK` — demonstrating the version fix.
+Re-run with `NVIM_VERSION=0.12.2` and both rows report `OK` — demonstrating the version fix.
 The script drives a real Neovim TUI in an isolated agent-tty session, auto-opens the plugin's
 Claude terminal (`PASTE_REPRO_AUTOOPEN=1`), pastes via bracketed paste, and reports segments.
+(`NVIM_VERSION` resolves the binary through mise without touching your active Neovim; pass an
+explicit `NVIM_BIN=/path/to/nvim` instead if you prefer.)
 
 ### B. Manual (interactive)
 
+The `vv` alias calls bare `nvim` (subject to whatever's first on `PATH`), so launch Neovim directly
+through `mise exec` instead — it runs the managed build unambiguously:
+
 ```bash
-source fixtures/nvim-aliases.sh
-PATH="$HOME/.local/share/mise/installs/neovim/0.11.6/bin:$PATH" vv paste-repro
+cd fixtures && \
+  NVIM_APPNAME=paste-repro XDG_CONFIG_HOME="$PWD" \
+  mise exec neovim@0.11.7 -- nvim
 ```
 
 Then inside Neovim:
@@ -114,9 +120,9 @@ Then inside Neovim:
 ### C. Pure-Neovim isolation (no plugin) — proves it's core, not the plugin
 
 ```bash
-NVIM=$HOME/.local/share/mise/installs/neovim/0.11.6/bin/nvim
-$NVIM --clean -c "terminal python3 $PWD/fixtures/paste-repro/observer.py /tmp/obs.log" -c startinsert
-# paste 100+ lines, then: grep TOTAL /tmp/obs.log   -> start_markers=6 on 0.11.6, =1 on 0.12.2
+mise exec neovim@0.11.7 -- nvim --clean \
+  -c "terminal python3 $PWD/fixtures/paste-repro/observer.py /tmp/obs.log" -c startinsert
+# paste 100+ lines, then: grep TOTAL /tmp/obs.log   -> start_markers=6 on 0.11.7, =1 on 0.12.2
 ```
 
 ## The workaround (and its edge cases)

--- a/fixtures/paste-repro/README.md
+++ b/fixtures/paste-repro/README.md
@@ -148,12 +148,15 @@ This is **shipped** in the plugin as of the change that added this fixture:
   segments to 1, byte-identical to 0.12.2. Set `fix_streamed_paste = false` to opt out, or `true`
   to force it on. Unit tests: `tests/unit/terminal/paste_fix_spec.lua`.
 
-The `APPLY_PASTE_FIX=1` toggle in this fixture applies the _standalone_ community override and is
-kept for isolating the workaround independently of the plugin.
+This fixture sets `terminal.fix_streamed_paste = false` by default so it reproduces the **raw** bug
+(`APPLY_PASTE_FIX` toggles the _standalone_ community override, kept for isolating the workaround
+independently of the plugin). To instead exercise the **shipped plugin fix** end-to-end, launch
+with `PASTE_REPRO_PLUGIN_FIX=auto` (or `=true`).
 
 ## Files
 
-- `init.lua` — fixture config (native provider; `terminal_cmd` → observer; `APPLY_PASTE_FIX`,
-  `PASTE_REPRO_AUTOOPEN`, `PASTE_OBSERVER_LOG` env toggles).
+- `init.lua` — fixture config (native provider; `terminal_cmd` → observer). Env toggles:
+  `APPLY_PASTE_FIX` (standalone workaround), `PASTE_REPRO_PLUGIN_FIX` (the plugin's own
+  `fix_streamed_paste`, default off here), `PASTE_REPRO_AUTOOPEN`, `PASTE_OBSERVER_LOG`.
 - `observer.py` — bracketed-paste segment counter (the measurement instrument).
 - `agent-repro.sh` — self-contained automated reproduction via agent-tty.

--- a/fixtures/paste-repro/README.md
+++ b/fixtures/paste-repro/README.md
@@ -129,15 +129,27 @@ fixture with `APPLY_PASTE_FIX=1`):
 - kyleawayan's refinement re-glues the mid-line chunk seam
   (`chunks[#chunks] = chunks[#chunks] .. lines[1]`); without it, every chunk boundary injects a
   spurious newline (because `lines` is a `readfile()`-style split with delimiters dropped).
-- **Residual edge case** (flagged for the fix phase, not verified here): a chunk boundary landing
-  exactly on a source newline could drop a legitimate newline. Worth a targeted test before
-  shipping.
+- **Residual edge case** (now verified safe): a chunk boundary landing exactly on a source newline
+  does _not_ drop a newline — a `readfile()`-style split of newline-terminated text yields a
+  trailing empty element, so the seam becomes a harmless empty-string concat. This was confirmed
+  byte-for-byte against fixed-Neovim output for newline-on-boundary, consecutive blank lines, no
+  trailing newline, CRLF, and a 20 KB multi-boundary paste.
 
-## Recommendation
+## Status / fix
+
+This is **shipped** in the plugin as of the change that added this fixture:
 
 - **Real fix:** upgrade Neovim to **0.12.2+**.
-- **Mitigation for users on 0.11.x / 0.12.1:** ship the coalescing `vim.paste` override behind a
-  config flag (e.g. `terminal.fix_streamed_paste`), scoped to `buftype == 'terminal'`.
+- **Plugin shim (default `"auto"`):** `lua/claudecode/terminal/paste_fix.lua` installs a scoped,
+  version-gated, cooperative `vim.paste` override (config: `terminal.fix_streamed_paste`). Unlike
+  the community snippet it is **scoped to the plugin's own managed terminal buffer** (not all
+  `:terminal` buffers), is a **no-op on Neovim >= 0.12.2**, and delegates to any pre-existing
+  `vim.paste`. Verified end-to-end: on 0.11.7 the shipped shim collapses a 20 KB paste from 6
+  segments to 1, byte-identical to 0.12.2. Set `fix_streamed_paste = false` to opt out, or `true`
+  to force it on. Unit tests: `tests/unit/terminal/paste_fix_spec.lua`.
+
+The `APPLY_PASTE_FIX=1` toggle in this fixture applies the _standalone_ community override and is
+kept for isolating the workaround independently of the plugin.
 
 ## Files
 

--- a/fixtures/paste-repro/agent-repro.sh
+++ b/fixtures/paste-repro/agent-repro.sh
@@ -14,21 +14,42 @@
 #
 # Requirements: agent-tty, python3, and one or more Neovim builds.
 # The bug is version-dependent (fixed upstream by neovim/neovim#39152, in 0.12.2):
-#   * Neovim 0.11.x / 0.12.1  -> reproduces (N segments)
-#   * Neovim 0.12.2+          -> single segment
-# Install older builds with mise, e.g.:  mise install neovim@0.11.6
+#   * Neovim 0.11.x / 0.12.0 / 0.12.1  -> reproduces (N segments)
+#   * Neovim 0.12.2+                   -> single segment
 #
 # Usage:
-#   ./agent-repro.sh                 # uses `nvim` on PATH, default + workaround
+#   ./agent-repro.sh                       # uses `nvim` on PATH
+#   NVIM_VERSION=0.11.7 ./agent-repro.sh   # run an old Neovim via mise (recommended)
 #   NVIM_BIN=/path/to/nvim ./agent-repro.sh
-#   LINES=300 ./agent-repro.sh       # bigger payload
+#   LINES=300 ./agent-repro.sh             # bigger payload
+#
+# NVIM_VERSION resolves the binary through mise. mise installs versions
+# side-by-side under its own cache, so this NEVER changes your active/default
+# Neovim (that only changes via `mise use`). To run one off without this script:
+#   mise exec neovim@0.11.7 -- nvim ...
 set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FIX_DIR="$(dirname "$HERE")" # .../fixtures
-NVIM="${NVIM_BIN:-$(command -v nvim)}"
 LINES="${LINES:-120}"
 export _ZO_DOCTOR=0
+
+# Resolve how to launch Neovim (used both verbatim and embedded in a `bash -lc`):
+#   explicit NVIM_BIN > NVIM_VERSION (via `mise exec`, side-by-side/ephemeral) > `nvim` on PATH.
+# `mise exec neovim@X -- nvim` resolves the managed tool directly, so it is not affected by other
+# nvim managers on PATH and never changes your active Neovim.
+if [ -n "${NVIM_BIN:-}" ]; then
+  NVIM="$NVIM_BIN"
+elif [ -n "${NVIM_VERSION:-}" ]; then
+  command -v mise >/dev/null || {
+    echo "ERROR: NVIM_VERSION set but mise not found on PATH"
+    exit 1
+  }
+  mise install "neovim@$NVIM_VERSION" >/dev/null 2>&1 || true
+  NVIM="mise exec neovim@$NVIM_VERSION -- nvim"
+else
+  NVIM="nvim"
+fi
 
 command -v agent-tty >/dev/null || {
   echo "ERROR: agent-tty not found on PATH"
@@ -38,8 +59,11 @@ command -v python3 >/dev/null || {
   echo "ERROR: python3 not found on PATH"
   exit 1
 }
-[ -x "$NVIM" ] || {
-  echo "ERROR: nvim not found (set NVIM_BIN)"
+# $NVIM may be a path, "nvim", or "mise exec neovim@X -- nvim", so smoke-test it
+# (unquoted, to word-split the launcher) rather than checking for an executable file.
+# shellcheck disable=SC2086
+$NVIM --version >/dev/null 2>&1 || {
+  echo "ERROR: could not run Neovim ('$NVIM'); set NVIM_BIN or NVIM_VERSION"
   exit 1
 }
 
@@ -56,7 +80,8 @@ path, n = sys.argv[1], int(sys.argv[2])
 open(path, "w").write("\n".join("L%03d: the quick brown fox jumps over the lazy dog" % i for i in range(1, n+1)) + "\n")
 PY
 echo "Payload: $LINES lines, $(wc -c <"$PAYLOAD") bytes"
-echo "Neovim:  $("$NVIM" --version | head -1)"
+# shellcheck disable=SC2086
+echo "Neovim:  $($NVIM --version | head -1)"
 echo
 
 run() { # run <apply_fix 0|1> <label>
@@ -66,7 +91,7 @@ run() { # run <apply_fix 0|1> <label>
   local a=(agent-tty --home "$AGENT_HOME")
   local sid
   sid="$("${a[@]}" create --json --cols 110 --rows 32 -- \
-    bash -lc "cd '$FIX_DIR' && PASTE_OBSERVER_LOG='$log' APPLY_PASTE_FIX='$fix' PASTE_REPRO_AUTOOPEN=1 NVIM_APPNAME=paste-repro XDG_CONFIG_HOME='$FIX_DIR' '$NVIM' --clean -u '$FIX_DIR/paste-repro/init.lua'" |
+    bash -lc "cd '$FIX_DIR' && PASTE_OBSERVER_LOG='$log' APPLY_PASTE_FIX='$fix' PASTE_REPRO_AUTOOPEN=1 NVIM_APPNAME=paste-repro XDG_CONFIG_HOME='$FIX_DIR' $NVIM --clean -u '$FIX_DIR/paste-repro/init.lua'" |
     python3 -c "import json,sys;print(json.load(sys.stdin)['result']['sessionId'])")"
   "${a[@]}" wait "$sid" --text 'OBSERVER READY' --timeout-ms 15000 --json >/dev/null 2>&1
   "${a[@]}" paste "$sid" "$(cat "$PAYLOAD")" --json >/dev/null 2>&1

--- a/fixtures/paste-repro/agent-repro.sh
+++ b/fixtures/paste-repro/agent-repro.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Self-contained, deterministic reproduction of claudecode.nvim issue #161
+# ("Cmd+V paste truncates content in the Claude Code terminal") using agent-tty.
+#
+# It drives a real Neovim TUI inside an agent-tty session, opens the plugin's
+# native Claude terminal (which here runs observer.py instead of `claude`), pastes
+# a large payload via bracketed paste, and reports how many ESC[200~/ESC[201~
+# bracketed-paste SEGMENTS the inner PTY received:
+#
+#   * > 1 segment  => BUG reproduced  (Claude would render N separate [Pasted text #k]
+#                                      placeholders => perceived truncation)
+#   *   1 segment  => correct         (one logical paste)
+#
+# Requirements: agent-tty, python3, and one or more Neovim builds.
+# The bug is version-dependent (fixed upstream by neovim/neovim#39152, in 0.12.2):
+#   * Neovim 0.11.x / 0.12.1  -> reproduces (N segments)
+#   * Neovim 0.12.2+          -> single segment
+# Install older builds with mise, e.g.:  mise install neovim@0.11.6
+#
+# Usage:
+#   ./agent-repro.sh                 # uses `nvim` on PATH, default + workaround
+#   NVIM_BIN=/path/to/nvim ./agent-repro.sh
+#   LINES=300 ./agent-repro.sh       # bigger payload
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIX_DIR="$(dirname "$HERE")" # .../fixtures
+NVIM="${NVIM_BIN:-$(command -v nvim)}"
+LINES="${LINES:-120}"
+export _ZO_DOCTOR=0
+
+command -v agent-tty >/dev/null || {
+  echo "ERROR: agent-tty not found on PATH"
+  exit 1
+}
+command -v python3 >/dev/null || {
+  echo "ERROR: python3 not found on PATH"
+  exit 1
+}
+[ -x "$NVIM" ] || {
+  echo "ERROR: nvim not found (set NVIM_BIN)"
+  exit 1
+}
+
+WORK="$(mktemp -d)"
+AGENT_HOME="$WORK/atty-home"
+mkdir -p "$AGENT_HOME"
+PAYLOAD="$WORK/payload.txt"
+trap 'agent-tty --home "$AGENT_HOME" gc --json >/dev/null 2>&1; rm -rf "$WORK"' EXIT
+
+# A multi-line payload big enough to span several TUI input reads (~1 KB chunks).
+python3 - "$PAYLOAD" "$LINES" <<'PY'
+import sys
+path, n = sys.argv[1], int(sys.argv[2])
+open(path, "w").write("\n".join("L%03d: the quick brown fox jumps over the lazy dog" % i for i in range(1, n+1)) + "\n")
+PY
+echo "Payload: $LINES lines, $(wc -c <"$PAYLOAD") bytes"
+echo "Neovim:  $("$NVIM" --version | head -1)"
+echo
+
+run() { # run <apply_fix 0|1> <label>
+  local fix="$1" label="$2"
+  local log="$WORK/observer_$label.log"
+  rm -f "$log" "$log.raw"
+  local a=(agent-tty --home "$AGENT_HOME")
+  local sid
+  sid="$("${a[@]}" create --json --cols 110 --rows 32 -- \
+    bash -lc "cd '$FIX_DIR' && PASTE_OBSERVER_LOG='$log' APPLY_PASTE_FIX='$fix' PASTE_REPRO_AUTOOPEN=1 NVIM_APPNAME=paste-repro XDG_CONFIG_HOME='$FIX_DIR' '$NVIM' --clean -u '$FIX_DIR/paste-repro/init.lua'" |
+    python3 -c "import json,sys;print(json.load(sys.stdin)['result']['sessionId'])")"
+  "${a[@]}" wait "$sid" --text 'OBSERVER READY' --timeout-ms 15000 --json >/dev/null 2>&1
+  "${a[@]}" paste "$sid" "$(cat "$PAYLOAD")" --json >/dev/null 2>&1
+  "${a[@]}" wait "$sid" --screen-stable-ms 1000 --timeout-ms 8000 --json >/dev/null 2>&1
+  "${a[@]}" type "$sid" '<<QUIT>>' --json >/dev/null 2>&1
+  "${a[@]}" wait "$sid" --screen-stable-ms 700 --timeout-ms 6000 --json >/dev/null 2>&1
+  local total
+  total="$(grep -E '^TOTAL' "$log" 2>/dev/null || echo 'NO LOG (terminal did not open)')"
+  local segs
+  segs="$(sed -n 's/.*start_markers=\([0-9]*\).*/\1/p' <<<"$total")"
+  local verdict="?"
+  [ "${segs:-0}" = "1" ] && verdict="OK (single paste)"
+  [ "${segs:-0}" -gt 1 ] 2>/dev/null && verdict="BUG (fragmented)"
+  printf '  %-28s %s  => %s\n' "$label" "$total" "$verdict"
+  "${a[@]}" send-keys "$sid" 'C-\' 'C-n' --json >/dev/null 2>&1
+  "${a[@]}" type "$sid" ':qa!' --json >/dev/null 2>&1
+  "${a[@]}" send-keys "$sid" Enter --json >/dev/null 2>&1
+  sleep 0.3
+  "${a[@]}" destroy "$sid" --json >/dev/null 2>&1
+}
+
+echo "Result (bracketed-paste segments seen by the inner PTY):"
+run 0 "default"
+run 1 "with-workaround"
+echo
+echo "Interpretation: on an affected Neovim (<= 0.11.x / 0.12.1) 'default' shows >1"
+echo "segment (bug); 'with-workaround' shows 1. On Neovim 0.12.2+ both show 1."

--- a/fixtures/paste-repro/agent-repro.sh
+++ b/fixtures/paste-repro/agent-repro.sh
@@ -81,7 +81,7 @@ run() { # run <apply_fix 0|1> <label>
   [ "${segs:-0}" = "1" ] && verdict="OK (single paste)"
   [ "${segs:-0}" -gt 1 ] 2>/dev/null && verdict="BUG (fragmented)"
   printf '  %-28s %s  => %s\n' "$label" "$total" "$verdict"
-  "${a[@]}" send-keys "$sid" 'C-\' 'C-n' --json >/dev/null 2>&1
+  "${a[@]}" send-keys "$sid" "C-\\" "C-n" --json >/dev/null 2>&1
   "${a[@]}" type "$sid" ':qa!' --json >/dev/null 2>&1
   "${a[@]}" send-keys "$sid" Enter --json >/dev/null 2>&1
   sleep 0.3

--- a/fixtures/paste-repro/init.lua
+++ b/fixtures/paste-repro/init.lua
@@ -73,6 +73,19 @@ if fix_active then
   end
 end
 
+-- Whether to enable the *plugin's own* paste shim. Defaults to false so the
+-- fixture reproduces the raw bug (with APPLY_PASTE_FIX as the controlled
+-- variable). Set PASTE_REPRO_PLUGIN_FIX=auto|true to instead exercise the
+-- shipped plugin fix end-to-end.
+local plugin_fix = os.getenv("PASTE_REPRO_PLUGIN_FIX")
+if plugin_fix == "auto" then
+  plugin_fix = "auto"
+elseif plugin_fix == "true" then
+  plugin_fix = true
+else
+  plugin_fix = false
+end
+
 local ok, claudecode = pcall(require, "claudecode")
 assert(ok, "Failed to load claudecode.nvim from repo root: " .. tostring(claudecode))
 
@@ -86,6 +99,12 @@ claudecode.setup({
   terminal = {
     provider = "native",
     auto_close = false,
+    -- Disabled by default so this fixture reproduces the RAW bug (APPLY_PASTE_FIX
+    -- is the controlled variable). If the plugin's shim ("auto") were left on, it
+    -- would coalesce the paste on exactly the affected Neovim versions, so the
+    -- "default" run could never observe the >1-segment fragmentation it is meant
+    -- to show. Set PASTE_REPRO_PLUGIN_FIX=auto to exercise the shipped fix.
+    fix_streamed_paste = plugin_fix,
   },
 })
 

--- a/fixtures/paste-repro/init.lua
+++ b/fixtures/paste-repro/init.lua
@@ -1,0 +1,133 @@
+-- Repro fixture for issue #161:
+--   "Pasting text with Cmd+V truncates content in the Claude Code terminal"
+--
+-- Root cause (confirmed): on Neovim <= 0.11.x, a single large bracketed paste
+-- into a :terminal buffer is streamed through vim.paste() in phases (1->2->3),
+-- and the default handler wraps EACH streamed write to the inner PTY in its own
+-- ESC[200~ ... ESC[201~ pair. Claude Code then classifies every segment as a
+-- separate paste event ("[Pasted text #N]"), which presents as truncation.
+-- Neovim 0.12+ coalesces the stream into a single bracketed-paste segment, so
+-- the bug does not reproduce there.
+--
+-- This fixture replaces the `claude` binary with a tiny bracketed-paste
+-- "observer" (observer.py) that logs how many ESC[200~/ESC[201~ segments the
+-- inner PTY receives. That count is the signal:
+--   * >1 segment  => bug reproduced (fragmentation)
+--   *  1 segment  => correct (single logical paste)
+--
+-- Usage (from repo root):
+--   source fixtures/nvim-aliases.sh
+--   vv paste-repro          # open Neovim with this fixture
+--   <leader>ac              # open the Claude terminal (runs the observer)
+--   then paste 100+ lines with Cmd+V and inspect the observer log
+--
+-- The observer log path is printed on startup (and via <leader>al). Toggle the
+-- proposed workaround with the APPLY_PASTE_FIX=1 environment variable.
+
+local config_dir = vim.fn.stdpath("config") -- fixtures/paste-repro
+local repo_root = vim.fn.fnamemodify(config_dir, ":h:h") -- repo root
+vim.opt.rtp:prepend(repo_root)
+
+-- Low-noise editor settings.
+vim.g.mapleader = " "
+vim.g.maplocalleader = "\\"
+vim.o.swapfile = false
+
+local observer = config_dir .. "/observer.py"
+local log = os.getenv("PASTE_OBSERVER_LOG") or (vim.fn.stdpath("cache") .. "/claudecode-paste-observer.log")
+
+-- Optional: apply the workaround proposed in issue #161 (huiyu + kyleawayan).
+-- Coalesces the streamed phases into a single phase == -1 paste so the inner
+-- PTY receives exactly one bracketed-paste segment.
+local fix_active = os.getenv("APPLY_PASTE_FIX") == "1"
+if fix_active then
+  local chunks = {}
+  local orig_paste = vim.paste
+  vim.paste = function(lines, phase)
+    if vim.bo.buftype ~= "terminal" or phase == -1 then
+      return orig_paste(lines, phase)
+    end
+    if phase == 1 then
+      chunks = {}
+    end
+    if #lines > 0 then
+      if #chunks == 0 then
+        for _, line in ipairs(lines) do
+          chunks[#chunks + 1] = line
+        end
+      else
+        -- The stream is split mid-line at chunk boundaries: the first incoming
+        -- line continues the last buffered line, so join them.
+        chunks[#chunks] = chunks[#chunks] .. lines[1]
+        for i = 2, #lines do
+          chunks[#chunks + 1] = lines[i]
+        end
+      end
+    end
+    if phase == 3 then
+      local buffered = chunks
+      chunks = {}
+      return orig_paste(buffered, -1)
+    end
+    return true
+  end
+end
+
+local ok, claudecode = pcall(require, "claudecode")
+assert(ok, "Failed to load claudecode.nvim from repo root: " .. tostring(claudecode))
+
+claudecode.setup({
+  auto_start = false,
+  log_level = "info",
+  -- Replace the `claude` CLI with the bracketed-paste observer. The observer
+  -- takes its log path as argv[1]. The native provider splits terminal_cmd on
+  -- spaces into an argv list, so neither path may contain spaces.
+  terminal_cmd = "python3 " .. observer .. " " .. log,
+  terminal = {
+    provider = "native",
+    auto_close = false,
+  },
+})
+
+local function ensure_started()
+  local ok_start, started_or_err, err = pcall(function()
+    return claudecode.start(false)
+  end)
+  if not ok_start then
+    vim.notify("ClaudeCode start crashed: " .. tostring(started_or_err), vim.log.levels.ERROR)
+    return false
+  end
+  if started_or_err or err == "Already running" then
+    return true
+  end
+  vim.notify("ClaudeCode failed to start: " .. tostring(err), vim.log.levels.ERROR)
+  return false
+end
+
+vim.keymap.set("n", "<leader>ac", function()
+  if ensure_started() then
+    require("claudecode.terminal").simple_toggle({}, nil)
+  end
+end, { desc = "Toggle Claude (observer) terminal" })
+
+vim.keymap.set("n", "<leader>al", function()
+  vim.notify("[paste-repro] observer log: " .. log)
+end, { desc = "Show observer log path" })
+
+-- Keep this message SHORT and on a single screen line: a banner long enough to
+-- wrap trips Neovim's "Press ENTER to continue" hit-enter prompt, which would
+-- swallow the <leader>ac keystroke when driving this fixture from a script.
+vim.schedule(function()
+  vim.notify("[paste-repro] ready" .. (fix_active and " (fix on)" or "") .. " — <leader>ac")
+end)
+
+-- For deterministic, non-interactive driving (e.g. agent-tty): when
+-- PASTE_REPRO_AUTOOPEN=1, open the observer terminal automatically on startup
+-- so the harness never has to time a <leader>ac keystroke.
+if os.getenv("PASTE_REPRO_AUTOOPEN") == "1" then
+  vim.schedule(function()
+    if ensure_started() then
+      require("claudecode.terminal").simple_toggle({}, nil)
+    end
+  end)
+end

--- a/fixtures/paste-repro/observer.py
+++ b/fixtures/paste-repro/observer.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Raw-mode bracketed-paste observer.
+
+Enables DECSET 2004 (bracketed paste), reads raw bytes, logs every read() with
+counts of paste START (ESC[200~) / END (ESC[201~) markers, and dumps every raw
+byte to <log>.raw for exact content reconstruction. Reveals whether one logical
+paste arrives as ONE bracketed-paste segment or is fragmented into many.
+
+Log path: argv[1] or $PASTE_LOG or <tmpdir>/claudecode-paste-observer.log
+Quit: raw byte 0x03 (Ctrl-C) or sentinel '<<QUIT>>'.
+"""
+import sys, os, tty, termios, time, tempfile
+
+LOG = (
+    (sys.argv[1] if len(sys.argv) > 1 else None)
+    or os.environ.get("PASTE_LOG")
+    or os.path.join(tempfile.gettempdir(), "claudecode-paste-observer.log")
+)
+RAW = LOG + ".raw"
+START = b"\x1b[200~"
+END = b"\x1b[201~"
+SENTINEL = b"<<QUIT>>"
+
+fd = sys.stdin.fileno()
+old = termios.tcgetattr(fd)
+log = open(LOG, "w", buffering=1)
+raw = open(RAW, "wb", buffering=0)
+
+os.write(1, b"\x1b[?2004h")
+os.write(1, b"OBSERVER READY (bracketed paste on). Paste now.\r\n")
+log.write("READY\n")
+
+tty.setraw(fd)
+allbytes = bytearray()
+reads = 0
+try:
+    while True:
+        chunk = os.read(fd, 65536)
+        if not chunk:
+            break
+        reads += 1
+        raw.write(chunk)
+        n_start = chunk.count(START)
+        n_end = chunk.count(END)
+        log.write(
+            "READ #%d ts=%.4f bytes=%d start=%d end=%d firstbytes=%r\n"
+            % (reads, time.time(), len(chunk), n_start, n_end, bytes(chunk[:24]))
+        )
+        allbytes += chunk
+        if b"\x03" in chunk or SENTINEL in allbytes:
+            break
+finally:
+    termios.tcsetattr(fd, termios.TCSADRAIN, old)
+    os.write(1, b"\x1b[?2004l")
+    log.write(
+        "TOTAL reads=%d total_bytes=%d start_markers=%d end_markers=%d\n"
+        % (reads, len(allbytes), allbytes.count(START), allbytes.count(END))
+    )
+    log.close(); raw.close()

--- a/lua/claudecode/terminal.lua
+++ b/lua/claudecode/terminal.lua
@@ -19,6 +19,11 @@ local defaults = {
   auto_close = true,
   env = {},
   snacks_win_opts = {},
+  -- Workaround for a Neovim core bug (< 0.12.2) that fragments large bracketed
+  -- pastes into the terminal; see lua/claudecode/terminal/paste_fix.lua and
+  -- https://github.com/coder/claudecode.nvim/issues/161.
+  -- true = force on, false = off, "auto" = on only for affected Neovim versions.
+  fix_streamed_paste = "auto",
   -- Working directory control
   cwd = nil, -- static cwd override
   git_repo_cwd = false, -- resolve to git root when spawning
@@ -453,6 +458,17 @@ function M.setup(user_term_config, p_terminal_cmd, p_env)
       else
         vim.notify("claudecode.terminal.setup: Invalid value for snacks_win_opts", vim.log.levels.WARN)
       end
+    elseif k == "fix_streamed_paste" then
+      if type(v) == "boolean" or v == "auto" then
+        defaults.fix_streamed_paste = v
+      else
+        vim.notify(
+          "claudecode.terminal.setup: Invalid value for fix_streamed_paste: "
+            .. tostring(v)
+            .. " (expected true, false, or 'auto')",
+          vim.log.levels.WARN
+        )
+      end
     elseif k == "cwd" then
       if v == nil or type(v) == "string" then
         defaults.cwd = v
@@ -491,6 +507,10 @@ function M.setup(user_term_config, p_terminal_cmd, p_env)
 
   -- Setup providers with config
   get_provider().setup(defaults)
+
+  -- Install the streamed-paste compatibility shim for issue #161. No-op on
+  -- Neovim >= 0.12.2 (and when disabled), scoped to the managed terminal buffer.
+  require("claudecode.terminal.paste_fix").apply(defaults.fix_streamed_paste)
 end
 
 ---Opens or focuses the Claude terminal.

--- a/lua/claudecode/terminal.lua
+++ b/lua/claudecode/terminal.lua
@@ -19,11 +19,7 @@ local defaults = {
   auto_close = true,
   env = {},
   snacks_win_opts = {},
-  -- Workaround for a Neovim core bug (< 0.12.2) that fragments large bracketed
-  -- pastes into the terminal; see lua/claudecode/terminal/paste_fix.lua and
-  -- https://github.com/coder/claudecode.nvim/issues/161.
-  -- true = force on, false = off, "auto" = on only for affected Neovim versions.
-  fix_streamed_paste = "auto",
+  fix_streamed_paste = "auto", -- work around Neovim <0.12.2 paste fragmentation (#161): true|false|"auto"
   -- Working directory control
   cwd = nil, -- static cwd override
   git_repo_cwd = false, -- resolve to git root when spawning
@@ -508,8 +504,7 @@ function M.setup(user_term_config, p_terminal_cmd, p_env)
   -- Setup providers with config
   get_provider().setup(defaults)
 
-  -- Install the streamed-paste compatibility shim for issue #161. No-op on
-  -- Neovim >= 0.12.2 (and when disabled), scoped to the managed terminal buffer.
+  -- Streamed-paste compatibility shim for #161 (no-op on Neovim >= 0.12.2).
   require("claudecode.terminal.paste_fix").apply(defaults.fix_streamed_paste)
 end
 

--- a/lua/claudecode/terminal/paste_fix.lua
+++ b/lua/claudecode/terminal/paste_fix.lua
@@ -12,7 +12,6 @@ local chunks = {} -- accumulator for the in-flight streamed paste (pastes are se
 local installed = false -- the global vim.paste wrap happens at most once
 local enabled = false -- config-controlled; lets a later setup() disable in place
 local streaming = false -- does the current stream target the managed terminal? (decided at phase 1)
-local target_buf = nil -- the managed terminal buffer captured at phase 1 of the current stream
 local terminal_mod = nil -- lazily required to avoid a terminal -> paste_fix cycle
 
 --- True if the running Neovim has the per-phase terminal-paste fragmentation
@@ -100,11 +99,10 @@ function M.install()
     end
 
     -- Decide once per stream (at phase 1) whether it targets the managed
-    -- terminal, capturing that buffer, so phases 2/3 stay coalesced even if
-    -- focus moves mid-stream.
+    -- terminal, so phases 2/3 follow that decision and we don't re-resolve the
+    -- provider on every phase.
     if phase == 1 then
-      target_buf = vim.api.nvim_get_current_buf()
-      streaming = is_managed_terminal(target_buf)
+      streaming = is_managed_terminal(vim.api.nvim_get_current_buf())
       chunks = {}
     end
 
@@ -118,21 +116,13 @@ function M.install()
       local buffered = chunks
       chunks = {}
       streaming = false
-      -- Common case: still on the terminal that started the paste. Let the
-      -- original handler replay it (it wraps in one bracketed segment and
-      -- respects the inner program's bracketed-paste state).
-      if vim.api.nvim_get_current_buf() == target_buf then
-        return orig_paste(buffered, -1)
-      end
-      -- Focus left the terminal mid-stream: replaying via the original handler
-      -- would dump the buffered text into whatever buffer is now current. Send
-      -- it straight to the captured terminal's channel instead, matching the
-      -- bytes Neovim would have written (one bracketed-paste segment).
-      local chan = vim.api.nvim_buf_is_valid(target_buf) and vim.bo[target_buf].channel
-      if chan and chan > 0 then
-        pcall(vim.api.nvim_chan_send, chan, "\27[200~" .. table.concat(buffered, "\n") .. "\27[201~")
-        return true
-      end
+      -- Replay as a single non-streamed paste through the original handler. We
+      -- deliberately delegate rather than writing to the terminal channel
+      -- ourselves: only Neovim's terminal paste knows whether the child enabled
+      -- bracketed paste (it is not queryable from Lua), so reconstructing the
+      -- ESC[200~/ESC[201~ framing ourselves would corrupt input for programs
+      -- that have not. (A focus change between phases is not reachable from a
+      -- TUI bracketed paste, which is processed as one atomic input burst.)
       return orig_paste(buffered, -1)
     end
     return true

--- a/lua/claudecode/terminal/paste_fix.lua
+++ b/lua/claudecode/terminal/paste_fix.lua
@@ -12,6 +12,7 @@ local chunks = {} -- accumulator for the in-flight streamed paste (pastes are se
 local installed = false -- the global vim.paste wrap happens at most once
 local enabled = false -- config-controlled; lets a later setup() disable in place
 local streaming = false -- does the current stream target the managed terminal? (decided at phase 1)
+local target_buf = nil -- the managed terminal buffer captured at phase 1 of the current stream
 local terminal_mod = nil -- lazily required to avoid a terminal -> paste_fix cycle
 
 --- True if the running Neovim has the per-phase terminal-paste fragmentation
@@ -99,9 +100,11 @@ function M.install()
     end
 
     -- Decide once per stream (at phase 1) whether it targets the managed
-    -- terminal, so phases 2/3 stay coalesced even if focus moves mid-stream.
+    -- terminal, capturing that buffer, so phases 2/3 stay coalesced even if
+    -- focus moves mid-stream.
     if phase == 1 then
-      streaming = is_managed_terminal(vim.api.nvim_get_current_buf())
+      target_buf = vim.api.nvim_get_current_buf()
+      streaming = is_managed_terminal(target_buf)
       chunks = {}
     end
 
@@ -115,7 +118,22 @@ function M.install()
       local buffered = chunks
       chunks = {}
       streaming = false
-      return orig_paste(buffered, -1) -- one non-streamed replay = one bracketed segment
+      -- Common case: still on the terminal that started the paste. Let the
+      -- original handler replay it (it wraps in one bracketed segment and
+      -- respects the inner program's bracketed-paste state).
+      if vim.api.nvim_get_current_buf() == target_buf then
+        return orig_paste(buffered, -1)
+      end
+      -- Focus left the terminal mid-stream: replaying via the original handler
+      -- would dump the buffered text into whatever buffer is now current. Send
+      -- it straight to the captured terminal's channel instead, matching the
+      -- bytes Neovim would have written (one bracketed-paste segment).
+      local chan = vim.api.nvim_buf_is_valid(target_buf) and vim.bo[target_buf].channel
+      if chan and chan > 0 then
+        pcall(vim.api.nvim_chan_send, chan, "\27[200~" .. table.concat(buffered, "\n") .. "\27[201~")
+        return true
+      end
+      return orig_paste(buffered, -1)
     end
     return true
   end

--- a/lua/claudecode/terminal/paste_fix.lua
+++ b/lua/claudecode/terminal/paste_fix.lua
@@ -12,6 +12,7 @@ local chunks = {} -- accumulator for the in-flight streamed paste (pastes are se
 local installed = false -- the global vim.paste wrap happens at most once
 local enabled = false -- config-controlled; lets a later setup() disable in place
 local streaming = false -- does the current stream target the managed terminal? (decided at phase 1)
+local target_win = nil -- window that owns the paste, captured at phase 1, for the phase-3 replay
 local terminal_mod = nil -- lazily required to avoid a terminal -> paste_fix cycle
 
 --- True if the running Neovim has the per-phase terminal-paste fragmentation
@@ -109,10 +110,11 @@ function M.install()
     end
 
     -- Decide once per stream (at phase 1) whether it targets the managed
-    -- terminal, so phases 2/3 follow that decision and we don't re-resolve the
-    -- provider on every phase.
+    -- terminal, capturing the window so phases 2/3 follow that decision and the
+    -- replay can be aimed back at it.
     if phase == 1 then
       streaming = is_managed_terminal(vim.api.nvim_get_current_buf())
+      target_win = vim.api.nvim_get_current_win()
       chunks = {}
     end
 
@@ -126,13 +128,18 @@ function M.install()
       local buffered = chunks
       chunks = {}
       streaming = false
-      -- Replay as a single non-streamed paste through the original handler. We
-      -- deliberately delegate rather than writing to the terminal channel
-      -- ourselves: only Neovim's terminal paste knows whether the child enabled
-      -- bracketed paste (it is not queryable from Lua), so reconstructing the
-      -- ESC[200~/ESC[201~ framing ourselves would corrupt input for programs
-      -- that have not. (A focus change between phases is not reachable from a
-      -- TUI bracketed paste, which is processed as one atomic input burst.)
+      -- Replay as a single non-streamed paste through the original handler so
+      -- Neovim's own terminal paste delivers it (and decides whether to emit
+      -- bracketed-paste markers based on the child's state — which is not
+      -- queryable from Lua). If focus has moved off the terminal since phase 1
+      -- (e.g. a scheduled callback or a GUI/RPC paste stream), run the replay in
+      -- the captured window via nvim_win_call so it still reaches the terminal
+      -- instead of the now-current buffer.
+      if target_win and target_win ~= vim.api.nvim_get_current_win() and vim.api.nvim_win_is_valid(target_win) then
+        return vim.api.nvim_win_call(target_win, function()
+          return orig_paste(buffered, -1)
+        end)
+      end
       return orig_paste(buffered, -1)
     end
     return true

--- a/lua/claudecode/terminal/paste_fix.lua
+++ b/lua/claudecode/terminal/paste_fix.lua
@@ -27,7 +27,17 @@ function M.is_affected_version()
   end
   local minor = v.minor or 0
   local patch = v.patch or 0
-  return minor < 12 or (minor == 12 and patch < 2)
+  if minor < 12 or (minor == 12 and patch < 2) then
+    return true
+  end
+  -- The fix shipped in the 0.12.2 *release*. A 0.12.2 prerelease/nightly
+  -- (vim.version().prerelease is set, e.g. "dev") can predate the backport, so
+  -- treat it as affected. Enabling the shim on a build that already has the fix
+  -- is a verified no-op, so erring toward "affected" at the boundary is safe.
+  if minor == 12 and patch == 2 and v.prerelease then
+    return true
+  end
+  return false
 end
 
 --- Resolve whether the shim should be active for a given config value.

--- a/lua/claudecode/terminal/paste_fix.lua
+++ b/lua/claudecode/terminal/paste_fix.lua
@@ -1,0 +1,148 @@
+--- Compatibility shim for a Neovim core bug that fragments large bracketed
+--- pastes into a `:terminal` buffer.
+---
+--- See https://github.com/coder/claudecode.nvim/issues/161 and the upstream fix
+--- https://github.com/neovim/neovim/pull/39152 (landed in Neovim 0.12.2).
+---
+--- On affected Neovim (< 0.12.2), the default `vim.paste` runs `nvim_put()` once
+--- per streamed phase (1 -> 2 -> 3). In a terminal buffer each write is
+--- independently wrapped in bracketed-paste markers (ESC[200~ .. ESC[201~) when
+--- the inner program enabled them, so a single large paste reaches the program
+--- running in the terminal (e.g. the Claude CLI) as N separate paste events.
+--- Claude renders N `[Pasted text #k]` placeholders with phase-boundary bytes
+--- leaking between them, which the user perceives as truncation.
+---
+--- This module installs a cooperative `vim.paste` override that coalesces the
+--- streamed phases of a paste into ONE non-streamed (`phase == -1`) replay, but
+--- only for the plugin's own managed terminal buffer. Everything else delegates
+--- to the original handler unchanged. The override is a no-op on Neovim >= 0.12.2
+--- (which already coalesces) unless explicitly forced.
+--- @module 'claudecode.terminal.paste_fix'
+
+local M = {}
+
+-- Accumulator for the in-flight streamed paste. Pastes are processed
+-- sequentially, so a single shared buffer is safe.
+local chunks = {}
+local installed = false
+
+--- True if the running Neovim has the per-phase terminal-paste fragmentation
+--- bug, i.e. is older than the 0.12.2 fix.
+--- @return boolean
+function M.is_affected_version()
+  local v = vim.version and vim.version()
+  if type(v) ~= "table" or type(v.major) ~= "number" then
+    return false
+  end
+  if v.major ~= 0 then
+    return false -- 1.0+ is well past the fix
+  end
+  return v.minor < 12 or (v.minor == 12 and (v.patch or 0) < 2)
+end
+
+--- Resolve whether the shim should be active for a given config value.
+--- @param opt boolean|string|nil `true` (force on), `false` (off), or `"auto"`/nil
+---        (on only for affected Neovim versions; the default).
+--- @return boolean
+function M.should_enable(opt)
+  if opt == false then
+    return false
+  end
+  if opt == true then
+    return true
+  end
+  -- "auto" / nil
+  return M.is_affected_version()
+end
+
+--- Append one streamed phase's `lines` to `acc`, re-gluing the mid-line seam.
+---
+--- `lines` is a `readfile()`-style split of the chunk on "\n" with the delimiters
+--- dropped, so when a paste is fragmented across chunks the boundary usually
+--- falls mid-line: the last element of the previous chunk and the first element
+--- of this chunk are two halves of the same source line. Appending naively would
+--- insert a spurious newline at every seam, so the first incoming line is joined
+--- onto the last buffered line instead.
+--- @param acc string[] accumulator (mutated in place)
+--- @param lines string[] the current phase's lines
+function M._accumulate(acc, lines)
+  if #lines == 0 then
+    return
+  end
+  if #acc == 0 then
+    for _, line in ipairs(lines) do
+      acc[#acc + 1] = line
+    end
+  else
+    acc[#acc] = acc[#acc] .. lines[1]
+    for i = 2, #lines do
+      acc[#acc + 1] = lines[i]
+    end
+  end
+end
+
+--- Whether `bufnr` is the plugin's managed Claude terminal buffer.
+--- @param bufnr integer
+--- @return boolean
+local function is_managed_terminal(bufnr)
+  if vim.bo[bufnr].buftype ~= "terminal" then
+    return false
+  end
+  -- Lazy require to avoid a load-time dependency cycle (terminal -> paste_fix).
+  local ok, terminal = pcall(require, "claudecode.terminal")
+  if not ok then
+    return false
+  end
+  local active = terminal.get_active_terminal_bufnr()
+  return active ~= nil and active == bufnr
+end
+
+--- Install the cooperative `vim.paste` override (idempotent). Captures the
+--- current `vim.paste` and delegates to it for everything except streamed pastes
+--- into the plugin's managed terminal buffer.
+function M.install()
+  if installed then
+    return
+  end
+  installed = true
+  chunks = {}
+
+  local orig_paste = vim.paste
+  vim.paste = function(lines, phase)
+    -- Only intervene for streamed pastes (phase 1/2/3) into the plugin's own
+    -- terminal buffer. `phase == -1` is already a whole, non-streamed paste.
+    if phase == -1 or not is_managed_terminal(vim.api.nvim_get_current_buf()) then
+      return orig_paste(lines, phase)
+    end
+
+    if phase == 1 then
+      chunks = {}
+    end
+    M._accumulate(chunks, lines)
+
+    if phase == 3 then
+      local buffered = chunks
+      chunks = {}
+      -- Replay as a single non-streamed paste so the terminal wraps it in one
+      -- bracketed-paste segment.
+      return orig_paste(buffered, -1)
+    end
+    return true
+  end
+end
+
+--- Apply the shim according to the resolved config value.
+--- @param opt boolean|string|nil
+function M.apply(opt)
+  if M.should_enable(opt) then
+    M.install()
+  end
+end
+
+--- Test helper: report whether the override has been installed.
+--- @return boolean
+function M._is_installed()
+  return installed
+end
+
+return M

--- a/lua/claudecode/terminal/paste_fix.lua
+++ b/lua/claudecode/terminal/paste_fix.lua
@@ -1,30 +1,18 @@
---- Compatibility shim for a Neovim core bug that fragments large bracketed
---- pastes into a `:terminal` buffer.
----
---- See https://github.com/coder/claudecode.nvim/issues/161 and the upstream fix
---- https://github.com/neovim/neovim/pull/39152 (landed in Neovim 0.12.2).
----
---- On affected Neovim (< 0.12.2), the default `vim.paste` runs `nvim_put()` once
---- per streamed phase (1 -> 2 -> 3). In a terminal buffer each write is
---- independently wrapped in bracketed-paste markers (ESC[200~ .. ESC[201~) when
---- the inner program enabled them, so a single large paste reaches the program
---- running in the terminal (e.g. the Claude CLI) as N separate paste events.
---- Claude renders N `[Pasted text #k]` placeholders with phase-boundary bytes
---- leaking between them, which the user perceives as truncation.
----
---- This module installs a cooperative `vim.paste` override that coalesces the
---- streamed phases of a paste into ONE non-streamed (`phase == -1`) replay, but
---- only for the plugin's own managed terminal buffer. Everything else delegates
---- to the original handler unchanged. The override is a no-op on Neovim >= 0.12.2
---- (which already coalesces) unless explicitly forced.
+--- Compatibility shim for a Neovim core bug (< 0.12.2) that fragments a large
+--- bracketed paste into a `:terminal` across `vim.paste` phases, so the program
+--- in the terminal sees it as N separate pastes. Coalesces the streamed phases
+--- into one `phase == -1` replay, scoped to the plugin's managed terminal; a
+--- no-op on Neovim >= 0.12.2 unless forced. See coder/claudecode.nvim#161 and the
+--- upstream fix neovim/neovim#39152.
 --- @module 'claudecode.terminal.paste_fix'
 
 local M = {}
 
--- Accumulator for the in-flight streamed paste. Pastes are processed
--- sequentially, so a single shared buffer is safe.
-local chunks = {}
-local installed = false
+local chunks = {} -- accumulator for the in-flight streamed paste (pastes are sequential)
+local installed = false -- the global vim.paste wrap happens at most once
+local enabled = false -- config-controlled; lets a later setup() disable in place
+local streaming = false -- does the current stream target the managed terminal? (decided at phase 1)
+local terminal_mod = nil -- lazily required to avoid a terminal -> paste_fix cycle
 
 --- True if the running Neovim has the per-phase terminal-paste fragmentation
 --- bug, i.e. is older than the 0.12.2 fix.
@@ -37,7 +25,9 @@ function M.is_affected_version()
   if v.major ~= 0 then
     return false -- 1.0+ is well past the fix
   end
-  return v.minor < 12 or (v.minor == 12 and (v.patch or 0) < 2)
+  local minor = v.minor or 0
+  local patch = v.patch or 0
+  return minor < 12 or (minor == 12 and patch < 2)
 end
 
 --- Resolve whether the shim should be active for a given config value.
@@ -55,86 +45,88 @@ function M.should_enable(opt)
   return M.is_affected_version()
 end
 
---- Append one streamed phase's `lines` to `acc`, re-gluing the mid-line seam.
----
---- `lines` is a `readfile()`-style split of the chunk on "\n" with the delimiters
---- dropped, so when a paste is fragmented across chunks the boundary usually
---- falls mid-line: the last element of the previous chunk and the first element
---- of this chunk are two halves of the same source line. Appending naively would
---- insert a spurious newline at every seam, so the first incoming line is joined
---- onto the last buffered line instead.
+--- Append one streamed phase's `lines` to `acc`. `lines` is a `readfile()`-style
+--- split, so consecutive chunks meet mid-line; re-glue the seam rather than
+--- inserting a spurious newline at every chunk boundary.
 --- @param acc string[] accumulator (mutated in place)
---- @param lines string[] the current phase's lines
+--- @param lines string[]
 function M._accumulate(acc, lines)
   if #lines == 0 then
     return
   end
-  if #acc == 0 then
-    for _, line in ipairs(lines) do
-      acc[#acc + 1] = line
-    end
-  else
-    acc[#acc] = acc[#acc] .. lines[1]
-    for i = 2, #lines do
-      acc[#acc + 1] = lines[i]
-    end
+  local start = 1
+  if #acc > 0 then
+    acc[#acc] = acc[#acc] .. lines[1] -- re-glue mid-line seam
+    start = 2
+  end
+  for i = start, #lines do
+    acc[#acc + 1] = lines[i]
   end
 end
 
---- Whether `bufnr` is the plugin's managed Claude terminal buffer.
+--- Whether `bufnr` is the plugin's managed terminal. Must never throw: it runs on
+--- the paste hot path, so failures degrade to "not managed".
 --- @param bufnr integer
 --- @return boolean
 local function is_managed_terminal(bufnr)
   if vim.bo[bufnr].buftype ~= "terminal" then
     return false
   end
-  -- Lazy require to avoid a load-time dependency cycle (terminal -> paste_fix).
-  local ok, terminal = pcall(require, "claudecode.terminal")
-  if not ok then
-    return false
+  if not terminal_mod then
+    local ok, mod = pcall(require, "claudecode.terminal")
+    if not ok then
+      return false
+    end
+    terminal_mod = mod
   end
-  local active = terminal.get_active_terminal_bufnr()
-  return active ~= nil and active == bufnr
+  local ok, active = pcall(terminal_mod.get_active_terminal_bufnr)
+  return ok and active ~= nil and active == bufnr
 end
 
---- Install the cooperative `vim.paste` override (idempotent). Captures the
---- current `vim.paste` and delegates to it for everything except streamed pastes
---- into the plugin's managed terminal buffer.
+--- Install the cooperative `vim.paste` override (idempotent). Delegates to the
+--- captured original except for a streamed paste into the managed terminal, and
+--- honours `enabled` at call time so it can be disabled without uninstalling.
 function M.install()
   if installed then
     return
   end
   installed = true
-  chunks = {}
 
   local orig_paste = vim.paste
   vim.paste = function(lines, phase)
-    -- Only intervene for streamed pastes (phase 1/2/3) into the plugin's own
-    -- terminal buffer. `phase == -1` is already a whole, non-streamed paste.
-    if phase == -1 or not is_managed_terminal(vim.api.nvim_get_current_buf()) then
+    if not enabled then
       return orig_paste(lines, phase)
     end
 
+    -- Decide once per stream (at phase 1) whether it targets the managed
+    -- terminal, so phases 2/3 stay coalesced even if focus moves mid-stream.
     if phase == 1 then
+      streaming = is_managed_terminal(vim.api.nvim_get_current_buf())
       chunks = {}
     end
+
+    if not streaming or phase == -1 then
+      return orig_paste(lines, phase)
+    end
+
     M._accumulate(chunks, lines)
 
     if phase == 3 then
       local buffered = chunks
       chunks = {}
-      -- Replay as a single non-streamed paste so the terminal wraps it in one
-      -- bracketed-paste segment.
-      return orig_paste(buffered, -1)
+      streaming = false
+      return orig_paste(buffered, -1) -- one non-streamed replay = one bracketed segment
     end
     return true
   end
 end
 
---- Apply the shim according to the resolved config value.
+--- Apply the shim per the resolved config value: set the active state (so a later
+--- call with `false` disables an installed override) and install on first enable.
 --- @param opt boolean|string|nil
 function M.apply(opt)
-  if M.should_enable(opt) then
+  enabled = M.should_enable(opt)
+  if enabled then
     M.install()
   end
 end
@@ -143,6 +135,12 @@ end
 --- @return boolean
 function M._is_installed()
   return installed
+end
+
+--- Test helper: report whether the override is currently active.
+--- @return boolean
+function M._is_enabled()
+  return enabled
 end
 
 return M

--- a/lua/claudecode/types.lua
+++ b/lua/claudecode/types.lua
@@ -87,6 +87,7 @@
 ---@field cwd string|nil                 -- static working directory for Claude terminal
 ---@field git_repo_cwd boolean|nil      -- use git root of current file/cwd as working directory
 ---@field cwd_provider? ClaudeCodeCwdProvider -- custom function to compute working directory
+---@field fix_streamed_paste boolean|"auto"|nil -- work around Neovim <0.12.2 terminal paste fragmentation (#161); "auto" (default) enables only on affected versions
 
 -- Port range configuration
 ---@class ClaudeCodePortRange

--- a/tests/unit/terminal/paste_fix_spec.lua
+++ b/tests/unit/terminal/paste_fix_spec.lua
@@ -11,13 +11,15 @@ describe("claudecode.terminal.paste_fix", function()
     paste_fix = require("claudecode.terminal.paste_fix")
   end
 
-  local saved_version, saved_paste, saved_bo, saved_get_buf
+  local saved_version, saved_paste, saved_bo, saved_get_buf, saved_buf_valid, saved_chan_send
 
   before_each(function()
     saved_version = vim.version
     saved_paste = vim.paste
     saved_bo = vim.bo
     saved_get_buf = vim.api.nvim_get_current_buf
+    saved_buf_valid = vim.api.nvim_buf_is_valid
+    saved_chan_send = vim.api.nvim_chan_send
     fresh()
   end)
 
@@ -26,6 +28,8 @@ describe("claudecode.terminal.paste_fix", function()
     vim.paste = saved_paste
     vim.bo = saved_bo
     vim.api.nvim_get_current_buf = saved_get_buf
+    vim.api.nvim_buf_is_valid = saved_buf_valid
+    vim.api.nvim_chan_send = saved_chan_send
     package.loaded["claudecode.terminal.paste_fix"] = nil
     package.loaded["claudecode.terminal"] = nil
   end)
@@ -126,21 +130,29 @@ describe("claudecode.terminal.paste_fix", function()
   end)
 
   describe("install (cooperative override)", function()
-    local managed_bufnr, current_bufnr, buftype_by_buf, orig_calls
+    local managed_bufnr, current_bufnr, buftype_by_buf, channel_by_buf, orig_calls, chan_sends
 
     -- Build a controlled vim environment for the override and install the shim.
     local function setup_env()
       managed_bufnr = 10
       current_bufnr = 10
       buftype_by_buf = { [10] = "terminal" }
+      channel_by_buf = { [10] = 77 }
       orig_calls = {}
+      chan_sends = {}
 
       vim.api.nvim_get_current_buf = function()
         return current_bufnr
       end
+      vim.api.nvim_buf_is_valid = function(b)
+        return buftype_by_buf[b] ~= nil
+      end
+      vim.api.nvim_chan_send = function(chan, data)
+        chan_sends[#chan_sends + 1] = { chan = chan, data = data }
+      end
       vim.bo = setmetatable({}, {
         __index = function(_, b)
-          return { buftype = buftype_by_buf[b] or "" }
+          return { buftype = buftype_by_buf[b] or "", channel = channel_by_buf[b] or 0 }
         end,
       })
       -- The original paste handler the shim must delegate to / replay through.
@@ -190,18 +202,20 @@ describe("claudecode.terminal.paste_fix", function()
       assert.are.same({ "whole" }, orig_calls[1].lines)
     end)
 
-    it("keeps buffered content when focus leaves the managed terminal mid-stream", function()
+    it("sends to the captured terminal's channel when focus leaves mid-stream", function()
       setup_env()
-      -- Phase 1 targets the managed terminal; the decision is latched.
+      -- Phase 1 targets the managed terminal (buf 10); the target is captured.
       assert.is_true(vim.paste({ "kept ", "dat" }, 1))
-      -- Focus moves away before phase 3 (active bufnr no longer current).
+      -- Focus moves to a normal buffer before phase 3.
       current_bufnr = 99
       buftype_by_buf[99] = ""
       vim.paste({ "a" }, 3)
-      -- Still coalesced into one replay; buffered content is not stranded.
-      assert.are.equal(1, #orig_calls)
-      assert.are.equal(-1, orig_calls[1].phase)
-      assert.are.same({ "kept ", "data" }, orig_calls[1].lines)
+      -- The buffered paste must NOT be dumped into the now-current buffer via the
+      -- original handler; it goes straight to the captured terminal's channel.
+      assert.are.equal(0, #orig_calls)
+      assert.are.equal(1, #chan_sends)
+      assert.are.equal(77, chan_sends[1].chan) -- buf 10's channel
+      assert.are.equal("\27[200~kept \ndata\27[201~", chan_sends[1].data)
     end)
 
     it("respects a later apply(false): delegates instead of coalescing", function()

--- a/tests/unit/terminal/paste_fix_spec.lua
+++ b/tests/unit/terminal/paste_fix_spec.lua
@@ -155,7 +155,8 @@ describe("claudecode.terminal.paste_fix", function()
           return managed_bufnr
         end,
       }
-      paste_fix.install()
+      -- apply(true) sets enabled and installs the override.
+      paste_fix.apply(true)
     end
 
     it("coalesces a streamed paste into one phase==-1 replay for the managed terminal", function()
@@ -169,12 +170,50 @@ describe("claudecode.terminal.paste_fix", function()
       assert.are.same({ "hello world", "second line" }, orig_calls[1].lines)
     end)
 
+    it("coalesces a three-phase (1->2->3) stream including the middle phase", function()
+      setup_env()
+      -- Source "foo\nbar\nbaz" streamed across three chunks, each split mid-line.
+      assert.is_true(vim.paste({ "foo", "ba" }, 1))
+      assert.is_true(vim.paste({ "r", "ba" }, 2))
+      assert.is_true(vim.paste({ "z" }, 3))
+
+      assert.are.equal(1, #orig_calls)
+      assert.are.equal(-1, orig_calls[1].phase)
+      assert.are.same({ "foo", "bar", "baz" }, orig_calls[1].lines)
+    end)
+
     it("delegates a non-streamed (phase==-1) paste unchanged", function()
       setup_env()
       vim.paste({ "whole" }, -1)
       assert.are.equal(1, #orig_calls)
       assert.are.equal(-1, orig_calls[1].phase)
       assert.are.same({ "whole" }, orig_calls[1].lines)
+    end)
+
+    it("keeps buffered content when focus leaves the managed terminal mid-stream", function()
+      setup_env()
+      -- Phase 1 targets the managed terminal; the decision is latched.
+      assert.is_true(vim.paste({ "kept ", "dat" }, 1))
+      -- Focus moves away before phase 3 (active bufnr no longer current).
+      current_bufnr = 99
+      buftype_by_buf[99] = ""
+      vim.paste({ "a" }, 3)
+      -- Still coalesced into one replay; buffered content is not stranded.
+      assert.are.equal(1, #orig_calls)
+      assert.are.equal(-1, orig_calls[1].phase)
+      assert.are.same({ "kept ", "data" }, orig_calls[1].lines)
+    end)
+
+    it("respects a later apply(false): delegates instead of coalescing", function()
+      setup_env()
+      paste_fix.apply(false) -- disable without uninstalling
+      assert.is_false(paste_fix._is_enabled())
+      vim.paste({ "a", "b" }, 1)
+      vim.paste({ "c" }, 3)
+      -- No coalescing: each phase passes straight through.
+      assert.are.equal(2, #orig_calls)
+      assert.are.equal(1, orig_calls[1].phase)
+      assert.are.equal(3, orig_calls[2].phase)
     end)
 
     it("delegates pastes into a non-managed terminal unchanged", function()

--- a/tests/unit/terminal/paste_fix_spec.lua
+++ b/tests/unit/terminal/paste_fix_spec.lua
@@ -11,15 +11,13 @@ describe("claudecode.terminal.paste_fix", function()
     paste_fix = require("claudecode.terminal.paste_fix")
   end
 
-  local saved_version, saved_paste, saved_bo, saved_get_buf, saved_buf_valid, saved_chan_send
+  local saved_version, saved_paste, saved_bo, saved_get_buf
 
   before_each(function()
     saved_version = vim.version
     saved_paste = vim.paste
     saved_bo = vim.bo
     saved_get_buf = vim.api.nvim_get_current_buf
-    saved_buf_valid = vim.api.nvim_buf_is_valid
-    saved_chan_send = vim.api.nvim_chan_send
     fresh()
   end)
 
@@ -28,8 +26,6 @@ describe("claudecode.terminal.paste_fix", function()
     vim.paste = saved_paste
     vim.bo = saved_bo
     vim.api.nvim_get_current_buf = saved_get_buf
-    vim.api.nvim_buf_is_valid = saved_buf_valid
-    vim.api.nvim_chan_send = saved_chan_send
     package.loaded["claudecode.terminal.paste_fix"] = nil
     package.loaded["claudecode.terminal"] = nil
   end)
@@ -130,29 +126,21 @@ describe("claudecode.terminal.paste_fix", function()
   end)
 
   describe("install (cooperative override)", function()
-    local managed_bufnr, current_bufnr, buftype_by_buf, channel_by_buf, orig_calls, chan_sends
+    local managed_bufnr, current_bufnr, buftype_by_buf, orig_calls
 
     -- Build a controlled vim environment for the override and install the shim.
     local function setup_env()
       managed_bufnr = 10
       current_bufnr = 10
       buftype_by_buf = { [10] = "terminal" }
-      channel_by_buf = { [10] = 77 }
       orig_calls = {}
-      chan_sends = {}
 
       vim.api.nvim_get_current_buf = function()
         return current_bufnr
       end
-      vim.api.nvim_buf_is_valid = function(b)
-        return buftype_by_buf[b] ~= nil
-      end
-      vim.api.nvim_chan_send = function(chan, data)
-        chan_sends[#chan_sends + 1] = { chan = chan, data = data }
-      end
       vim.bo = setmetatable({}, {
         __index = function(_, b)
-          return { buftype = buftype_by_buf[b] or "", channel = channel_by_buf[b] or 0 }
+          return { buftype = buftype_by_buf[b] or "" }
         end,
       })
       -- The original paste handler the shim must delegate to / replay through.
@@ -202,20 +190,19 @@ describe("claudecode.terminal.paste_fix", function()
       assert.are.same({ "whole" }, orig_calls[1].lines)
     end)
 
-    it("sends to the captured terminal's channel when focus leaves mid-stream", function()
+    it("coalesces into a single replay even if focus leaves mid-stream", function()
       setup_env()
-      -- Phase 1 targets the managed terminal (buf 10); the target is captured.
+      -- Phase 1 targets the managed terminal; the streaming decision is latched.
       assert.is_true(vim.paste({ "kept ", "dat" }, 1))
       -- Focus moves to a normal buffer before phase 3.
       current_bufnr = 99
       buftype_by_buf[99] = ""
       vim.paste({ "a" }, 3)
-      -- The buffered paste must NOT be dumped into the now-current buffer via the
-      -- original handler; it goes straight to the captured terminal's channel.
-      assert.are.equal(0, #orig_calls)
-      assert.are.equal(1, #chan_sends)
-      assert.are.equal(77, chan_sends[1].chan) -- buf 10's channel
-      assert.are.equal("\27[200~kept \ndata\27[201~", chan_sends[1].data)
+      -- Still one coalesced replay through the original handler (delivery is
+      -- delegated to vim.paste rather than reconstructed by us).
+      assert.are.equal(1, #orig_calls)
+      assert.are.equal(-1, orig_calls[1].phase)
+      assert.are.same({ "kept ", "data" }, orig_calls[1].lines)
     end)
 
     it("respects a later apply(false): delegates instead of coalescing", function()

--- a/tests/unit/terminal/paste_fix_spec.lua
+++ b/tests/unit/terminal/paste_fix_spec.lua
@@ -123,6 +123,27 @@ describe("claudecode.terminal.paste_fix", function()
         assert.are.equal(expected, paste_fix.is_affected_version())
       end)
     end
+
+    it("treats a 0.12.2 prerelease (nightly built before the backport) as affected", function()
+      vim.version = function()
+        return { major = 0, minor = 12, patch = 2, prerelease = "dev" }
+      end
+      assert.is_true(paste_fix.is_affected_version())
+    end)
+
+    it("treats the 0.12.2 release (no prerelease) as fixed", function()
+      vim.version = function()
+        return { major = 0, minor = 12, patch = 2, prerelease = nil }
+      end
+      assert.is_false(paste_fix.is_affected_version())
+    end)
+
+    it("treats a 0.13.0 prerelease as fixed (past the boundary)", function()
+      vim.version = function()
+        return { major = 0, minor = 13, patch = 0, prerelease = "dev" }
+      end
+      assert.is_false(paste_fix.is_affected_version())
+    end)
   end)
 
   describe("install (cooperative override)", function()

--- a/tests/unit/terminal/paste_fix_spec.lua
+++ b/tests/unit/terminal/paste_fix_spec.lua
@@ -11,13 +11,16 @@ describe("claudecode.terminal.paste_fix", function()
     paste_fix = require("claudecode.terminal.paste_fix")
   end
 
-  local saved_version, saved_paste, saved_bo, saved_get_buf
+  local saved_version, saved_paste, saved_bo, saved_get_buf, saved_get_win, saved_win_valid, saved_win_call
 
   before_each(function()
     saved_version = vim.version
     saved_paste = vim.paste
     saved_bo = vim.bo
     saved_get_buf = vim.api.nvim_get_current_buf
+    saved_get_win = vim.api.nvim_get_current_win
+    saved_win_valid = vim.api.nvim_win_is_valid
+    saved_win_call = vim.api.nvim_win_call
     fresh()
   end)
 
@@ -26,6 +29,9 @@ describe("claudecode.terminal.paste_fix", function()
     vim.paste = saved_paste
     vim.bo = saved_bo
     vim.api.nvim_get_current_buf = saved_get_buf
+    vim.api.nvim_get_current_win = saved_get_win
+    vim.api.nvim_win_is_valid = saved_win_valid
+    vim.api.nvim_win_call = saved_win_call
     package.loaded["claudecode.terminal.paste_fix"] = nil
     package.loaded["claudecode.terminal"] = nil
   end)
@@ -148,16 +154,29 @@ describe("claudecode.terminal.paste_fix", function()
 
   describe("install (cooperative override)", function()
     local managed_bufnr, current_bufnr, buftype_by_buf, orig_calls
+    local current_win, win_calls
 
     -- Build a controlled vim environment for the override and install the shim.
     local function setup_env()
       managed_bufnr = 10
       current_bufnr = 10
       buftype_by_buf = { [10] = "terminal" }
+      current_win = 1000 -- the managed terminal's window
+      win_calls = {}
       orig_calls = {}
 
       vim.api.nvim_get_current_buf = function()
         return current_bufnr
+      end
+      vim.api.nvim_get_current_win = function()
+        return current_win
+      end
+      vim.api.nvim_win_is_valid = function(_)
+        return true
+      end
+      vim.api.nvim_win_call = function(win, fn)
+        win_calls[#win_calls + 1] = win
+        return fn()
       end
       vim.bo = setmetatable({}, {
         __index = function(_, b)
@@ -211,19 +230,30 @@ describe("claudecode.terminal.paste_fix", function()
       assert.are.same({ "whole" }, orig_calls[1].lines)
     end)
 
-    it("coalesces into a single replay even if focus leaves mid-stream", function()
+    it("replays in the captured window if focus leaves mid-stream", function()
       setup_env()
-      -- Phase 1 targets the managed terminal; the streaming decision is latched.
+      -- Phase 1 targets the managed terminal in window 1000; both are captured.
       assert.is_true(vim.paste({ "kept ", "dat" }, 1))
-      -- Focus moves to a normal buffer before phase 3.
+      -- Focus moves to a different window/buffer before phase 3.
       current_bufnr = 99
       buftype_by_buf[99] = ""
+      current_win = 2000
       vim.paste({ "a" }, 3)
-      -- Still one coalesced replay through the original handler (delivery is
-      -- delegated to vim.paste rather than reconstructed by us).
+      -- The coalesced replay is run in the captured terminal window (1000) via
+      -- nvim_win_call, delegating delivery/framing to the original handler.
+      assert.are.same({ 1000 }, win_calls)
       assert.are.equal(1, #orig_calls)
       assert.are.equal(-1, orig_calls[1].phase)
       assert.are.same({ "kept ", "data" }, orig_calls[1].lines)
+    end)
+
+    it("replays directly (no win_call) when focus stays on the terminal", function()
+      setup_env()
+      vim.paste({ "x", "y" }, 1)
+      vim.paste({ "z" }, 3) -- still in window 1000
+      assert.are.equal(0, #win_calls)
+      assert.are.equal(1, #orig_calls)
+      assert.are.equal(-1, orig_calls[1].phase)
     end)
 
     it("respects a later apply(false): delegates instead of coalescing", function()

--- a/tests/unit/terminal/paste_fix_spec.lua
+++ b/tests/unit/terminal/paste_fix_spec.lua
@@ -1,0 +1,209 @@
+require("tests.busted_setup")
+require("tests.mocks.vim")
+
+-- Tests for the streamed-paste compatibility shim (issue #161).
+describe("claudecode.terminal.paste_fix", function()
+  local paste_fix
+
+  -- Reload the module fresh each test so its `installed`/`chunks` state resets.
+  local function fresh()
+    package.loaded["claudecode.terminal.paste_fix"] = nil
+    paste_fix = require("claudecode.terminal.paste_fix")
+  end
+
+  local saved_version, saved_paste, saved_bo, saved_get_buf
+
+  before_each(function()
+    saved_version = vim.version
+    saved_paste = vim.paste
+    saved_bo = vim.bo
+    saved_get_buf = vim.api.nvim_get_current_buf
+    fresh()
+  end)
+
+  after_each(function()
+    vim.version = saved_version
+    vim.paste = saved_paste
+    vim.bo = saved_bo
+    vim.api.nvim_get_current_buf = saved_get_buf
+    package.loaded["claudecode.terminal.paste_fix"] = nil
+    package.loaded["claudecode.terminal"] = nil
+  end)
+
+  describe("_accumulate (seam-join)", function()
+    it("appends all lines when the accumulator is empty", function()
+      local acc = {}
+      paste_fix._accumulate(acc, { "alpha", "beta" })
+      assert.are.same({ "alpha", "beta" }, acc)
+    end)
+
+    it("joins the first incoming line onto the last buffered line (mid-line seam)", function()
+      -- Source "hello world\nsecond line" streamed as:
+      --   chunk1 "hello world\nsec"  -> {"hello world", "sec"}
+      --   chunk2 "ond line"          -> {"ond line"}
+      local acc = {}
+      paste_fix._accumulate(acc, { "hello world", "sec" })
+      paste_fix._accumulate(acc, { "ond line" })
+      assert.are.same({ "hello world", "second line" }, acc)
+    end)
+
+    it("preserves genuine newlines within a single chunk", function()
+      local acc = {}
+      paste_fix._accumulate(acc, { "one", "two", "three" })
+      assert.are.same({ "one", "two", "three" }, acc)
+    end)
+
+    it("does nothing for an empty lines table", function()
+      local acc = { "kept" }
+      paste_fix._accumulate(acc, {})
+      assert.are.same({ "kept" }, acc)
+    end)
+
+    it("reconstructs a single long line split across many chunks", function()
+      -- One source line with no newlines, fragmented mid-line repeatedly.
+      local acc = {}
+      paste_fix._accumulate(acc, { "the quick " })
+      paste_fix._accumulate(acc, { "brown fox " })
+      paste_fix._accumulate(acc, { "jumps" })
+      assert.are.same({ "the quick brown fox jumps" }, acc)
+    end)
+
+    it("handles a blank line straddling a chunk boundary", function()
+      -- Source "a\n\nb" streamed as chunk1 "a\n" -> {"a",""}, chunk2 "\nb" -> {"","b"}
+      local acc = {}
+      paste_fix._accumulate(acc, { "a", "" })
+      paste_fix._accumulate(acc, { "", "b" })
+      -- seam joins "" .. "" => still empty; result keeps both blank separations
+      assert.are.same({ "a", "", "b" }, acc)
+    end)
+  end)
+
+  describe("should_enable", function()
+    it("returns false when explicitly disabled", function()
+      assert.is_false(paste_fix.should_enable(false))
+    end)
+
+    it("returns true when explicitly forced", function()
+      assert.is_true(paste_fix.should_enable(true))
+    end)
+
+    it("delegates to version detection for 'auto' and nil", function()
+      vim.version = function()
+        return { major = 0, minor = 11, patch = 7 }
+      end
+      assert.is_true(paste_fix.should_enable("auto"))
+      assert.is_true(paste_fix.should_enable(nil))
+
+      vim.version = function()
+        return { major = 0, minor = 12, patch = 2 }
+      end
+      assert.is_false(paste_fix.should_enable("auto"))
+      assert.is_false(paste_fix.should_enable(nil))
+    end)
+  end)
+
+  describe("is_affected_version", function()
+    local cases = {
+      { { 0, 8, 0 }, true },
+      { { 0, 11, 5 }, true },
+      { { 0, 11, 7 }, true },
+      { { 0, 12, 0 }, true },
+      { { 0, 12, 1 }, true },
+      { { 0, 12, 2 }, false },
+      { { 0, 12, 3 }, false },
+      { { 0, 13, 0 }, false },
+      { { 1, 0, 0 }, false },
+    }
+    for _, case in ipairs(cases) do
+      local ver, expected = case[1], case[2]
+      it(string.format("%d.%d.%d -> affected=%s", ver[1], ver[2], ver[3], tostring(expected)), function()
+        vim.version = function()
+          return { major = ver[1], minor = ver[2], patch = ver[3] }
+        end
+        assert.are.equal(expected, paste_fix.is_affected_version())
+      end)
+    end
+  end)
+
+  describe("install (cooperative override)", function()
+    local managed_bufnr, current_bufnr, buftype_by_buf, orig_calls
+
+    -- Build a controlled vim environment for the override and install the shim.
+    local function setup_env()
+      managed_bufnr = 10
+      current_bufnr = 10
+      buftype_by_buf = { [10] = "terminal" }
+      orig_calls = {}
+
+      vim.api.nvim_get_current_buf = function()
+        return current_bufnr
+      end
+      vim.bo = setmetatable({}, {
+        __index = function(_, b)
+          return { buftype = buftype_by_buf[b] or "" }
+        end,
+      })
+      -- The original paste handler the shim must delegate to / replay through.
+      vim.paste = function(lines, phase)
+        orig_calls[#orig_calls + 1] = { lines = lines, phase = phase }
+        return true
+      end
+      -- Stub the terminal module so is_managed_terminal resolves without loading
+      -- the real (heavy) module.
+      package.loaded["claudecode.terminal"] = {
+        get_active_terminal_bufnr = function()
+          return managed_bufnr
+        end,
+      }
+      paste_fix.install()
+    end
+
+    it("coalesces a streamed paste into one phase==-1 replay for the managed terminal", function()
+      setup_env()
+      -- Source "hello world\nsecond line" streamed across two chunks.
+      assert.is_true(vim.paste({ "hello world", "sec" }, 1))
+      assert.is_true(vim.paste({ "ond line" }, 3))
+
+      assert.are.equal(1, #orig_calls)
+      assert.are.equal(-1, orig_calls[1].phase)
+      assert.are.same({ "hello world", "second line" }, orig_calls[1].lines)
+    end)
+
+    it("delegates a non-streamed (phase==-1) paste unchanged", function()
+      setup_env()
+      vim.paste({ "whole" }, -1)
+      assert.are.equal(1, #orig_calls)
+      assert.are.equal(-1, orig_calls[1].phase)
+      assert.are.same({ "whole" }, orig_calls[1].lines)
+    end)
+
+    it("delegates pastes into a non-managed terminal unchanged", function()
+      setup_env()
+      current_bufnr = 99 -- not the managed terminal
+      buftype_by_buf[99] = "terminal"
+      vim.paste({ "x" }, 1)
+      vim.paste({ "y" }, 3)
+      -- Each phase passed straight through; no coalescing.
+      assert.are.equal(2, #orig_calls)
+      assert.are.equal(1, orig_calls[1].phase)
+      assert.are.equal(3, orig_calls[2].phase)
+    end)
+
+    it("delegates pastes into a normal (non-terminal) buffer unchanged", function()
+      setup_env()
+      current_bufnr = 10
+      buftype_by_buf[10] = "" -- normal buffer
+      vim.paste({ "code" }, 1)
+      assert.are.equal(1, #orig_calls)
+      assert.are.equal(1, orig_calls[1].phase)
+    end)
+
+    it("is idempotent (does not double-wrap vim.paste)", function()
+      setup_env()
+      local after_first = vim.paste
+      paste_fix.install()
+      assert.are.equal(after_first, vim.paste)
+      assert.is_true(paste_fix._is_installed())
+    end)
+  end)
+end)


### PR DESCRIPTION
Fixes #161

## Problem

Pasting a large block (Cmd+V) into the Claude Code terminal appeared to **truncate** — the terminal showed multiple `[Pasted text #N]` placeholders with stray characters, while right-click paste worked.

## Root cause (upstream Neovim, not this plugin)

This is an upstream Neovim core bug — [`neovim/neovim#39110`](https://github.com/neovim/neovim/issues/39110), fixed by [`#39152`](https://github.com/neovim/neovim/pull/39152) in **0.12.2**. On affected Neovim the default `vim.paste` runs `nvim_put()` once per streamed phase (1→2→3), and each write into a `:terminal` is independently wrapped in bracketed-paste markers (`ESC[200~ … ESC[201~`), so one logical paste reaches Claude as **N separate paste events**. The plugin never touched the paste path — it inherited the behavior. The fix was **not** backported to the 0.11 line (0.11.7 still reproduces), so users there can't fix it by upgrading in place.

## What this PR does

Adds a scoped, version-gated `vim.paste` compatibility shim (`lua/claudecode/terminal/paste_fix.lua`), controlled by a new `terminal.fix_streamed_paste` option:

- **`"auto"` (default)** — enabled only on affected Neovim (`< 0.12.2`); a no-op otherwise. `true` forces it on, `false` disables it.
- **Scoped** to the plugin's own managed terminal buffer; delegates to the existing `vim.paste` for every other buffer, mode, and `phase == -1`.
- **Coalesces** the streamed phases into one `phase == -1` replay (one bracketed segment), with a mid-line seam-join so no spurious newlines are introduced.
- **Hot-path safe**: the managed-terminal decision is latched once per stream (so a mid-stream focus change can't strand buffered content), the provider lookup is `pcall`-guarded (can't break pasting editor-wide), and the config is dynamic (a later `setup{ fix_streamed_paste = false }` disables it without uninstalling).

The real fix remains **upgrade to Neovim 0.12.2+**; this is a compatibility shim for users on 0.11.x / 0.12.0 / 0.12.1.

## Verification

Reproduced and fixed empirically with a new `fixtures/paste-repro/` harness (a bracketed-paste "observer" stands in for `claude` and counts how many `ESC[200~`/`ESC[201~` segments the inner PTY receives), driven via [`agent-tty`](https://github.com/coder/agent-tty):

| Neovim | default | with shim |
| --- | --- | --- |
| 0.11.5 / 0.11.6 / 0.11.7 / 0.12.0 / 0.12.1 | 🐛 6 segments | ✅ 1 segment |
| 0.12.2 | ✅ 1 segment | ✅ 1 segment (no-op) |

The shipped shim's output is **byte-identical** to fixed-Neovim (0.12.2) output across edge cases: newline-on-chunk-boundary, consecutive blank lines, no trailing newline, CRLF, and a 20 KB multi-boundary paste.

## Test plan

- `mise run all` → 456 tests pass, luacheck 0 warnings, treefmt clean.
- 26 new unit tests in `tests/unit/terminal/paste_fix_spec.lua` (coalescing incl. phase 2, mid-stream focus change, dynamic disable, version gate, seam-join edge cases).
- End-to-end re-verified on Neovim 0.11.7 (raw bug reproduces; shipped shim collapses 6→1) via `fixtures/paste-repro/agent-repro.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
