### PR TITLE
ci: add AI release-notes automation via communique

### DIFF
--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -1,0 +1,82 @@
+name: Release Notes
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: write
+
+jobs:
+  release-notes:
+    name: release-notes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate release inputs
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          : "${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY secret is required}"
+          : "${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
+          : "${RELEASE_TAG:?release tag is required}"
+
+          case "$RELEASE_TAG" in
+            v*) ;;
+            *)
+              echo "release tag must start with 'v': $RELEASE_TAG" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      # install_args installs only communique (pinned in mise.toml), not the
+      # full dev toolchain. cache: false avoids zizmor's cache-poisoning finding
+      # on this publish workflow (caching saves little on a release-only job).
+      - name: Set up mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          install_args: communique
+          cache: false
+
+      - name: Resolve previous release ref
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          release_commit="$(git rev-parse --verify "${RELEASE_TAG}^{commit}")"
+          : "${release_commit:?release commit is required}"
+
+          if previous_ref="$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' --exclude '*-*' "${release_commit}^" 2>/dev/null)"; then
+            echo "Previous release tag: $previous_ref"
+          else
+            previous_ref="$(git rev-list --max-parents=0 "$release_commit" | head -n 1)"
+            : "${previous_ref:?previous release ref is required}"
+            echo "No previous release tag found; using root commit: $previous_ref"
+          fi
+
+          echo "PREVIOUS_RELEASE_REF=$previous_ref" >> "$GITHUB_ENV"
+
+      - name: Generate GitHub release notes
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          : "${PREVIOUS_RELEASE_REF:?previous release ref is required}"
+
+          communique generate "$RELEASE_TAG" "$PREVIOUS_RELEASE_REF" \
+            --github-release --repo "${{ github.repository }}"

--- a/communique.toml
+++ b/communique.toml
@@ -1,0 +1,19 @@
+context = """
+claudecode.nvim is a Neovim plugin written in pure Lua with zero dependencies. It implements the same WebSocket-based MCP protocol as Anthropic's official IDE extensions, letting the Claude CLI drive Neovim: opening files, reading selections and diagnostics, showing native diffs, and managing terminal sessions.
+
+Releases matter to Neovim users who install the plugin via their package manager and to integrators relying on MCP tool behavior. Call out changes to the public setup() configuration (such as terminal or diff_opts), MCP tool behavior and compatibility with the VS Code extension, supported Neovim versions, file explorer and terminal integrations (snacks.nvim, native, external, nvim-tree, oil.nvim, neo-tree, mini.files), and any breaking changes to keybindings or commands.
+
+Primary readers are Neovim users and plugin integrators, not the plugin's own maintainers, so frame notes around user-visible impact rather than internal refactors.
+"""
+
+system_extra = """
+Write direct, practical release notes for Neovim users and integrators.
+Lead with what changed and why it matters.
+Group changes into clear sections (for example Features, Fixes, Breaking Changes) and keep them concise.
+Avoid marketing language.
+Provide concrete migration guidance when configuration options, commands, or MCP tool behavior changed.
+Do not invent changes that are not supported by the commits, pull requests, or diffs.
+"""
+
+[defaults]
+model = "claude-opus-4-8"

--- a/mise.lock
+++ b/mise.lock
@@ -14,6 +14,22 @@ checksum = "sha256:aba9ced2dee8d27fecca3dc7feb1a7f9a52caefa1eb46f3271ea66b6e0e69
 url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_darwin_arm64.tar.gz"
 provenance = "github-attestations"
 
+[[tools.communique]]
+version = "1.1.3"
+backend = "github:jdx/communique"
+
+[tools.communique."platforms.linux-x64"]
+checksum = "sha256:61b46cf231882e0a10e0489df310ec9b875e83da0f38b60d6ac7bd67e09a15dc"
+url = "https://github.com/jdx/communique/releases/download/v1.1.3/communique-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/413753688"
+provenance = "github-attestations"
+
+[tools.communique."platforms.macos-arm64"]
+checksum = "sha256:7113bdb84a75ca23cccada1acc348a0770ec16a4b12a128f7b3f6b8c7764d10c"
+url = "https://github.com/jdx/communique/releases/download/v1.1.3/communique-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/413753891"
+provenance = "github-attestations"
+
 [[tools.fzf]]
 version = "0.73.1"
 backend = "aqua:junegunn/fzf"

--- a/mise.toml
+++ b/mise.toml
@@ -54,6 +54,7 @@ zizmor = "1.25.2"
 websocat = "1.14.1"
 jq = "1.8.1"
 fzf = "0.73.1"
+communique = "1.1.3"
 
 [env]
 # Lua test rocks (busted/luacheck/luacov) live in a project-local tree that


### PR DESCRIPTION
## What

Adds a `Release Notes` GitHub Actions workflow that, on every **published release**, generates editorialized release notes with [communique](https://github.com/jdx/communique) and overwrites the GitHub release body.

## How

- **`.github/workflows/release-notes.yaml`** — triggers on `release: published`; validates inputs, resolves the previous `vX.Y.Z` tag, and runs `communique generate <tag> <prev> --github-release`.
- **`communique.toml`** — project context + tone for the model, and pins the model to `claude-opus-4-8`.
- **`mise.toml` / `mise.lock`** — `communique` is provisioned through mise (pinned + checksum-verified), consistent with the rest of the toolchain.

### Notes
- The workflow installs **only** communique via mise-action's `install_args` (not the full dev toolchain).
- `cache: false` on mise-action — this is a privileged (`contents: write`), publish-triggered job, so caching is disabled to avoid zizmor's cache-poisoning finding (enforced via treefmt); the cache saves little on a release-only job.
- Uses the existing `ANTHROPIC_API_KEY` secret and the auto-provided `GITHUB_TOKEN`.
- Replaces the GitHub release body only; does not maintain `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)