### PR TITLE
fix(diff): exclude Snacks Explorer layout box from editor window detection

### DIFF
--- a/fixtures/snacks-explorer/README.md
+++ b/fixtures/snacks-explorer/README.md
@@ -1,0 +1,56 @@
+# snacks-explorer fixture — reproduction for issue #236
+
+Reproduces [#236](https://github.com/coder/claudecode.nvim/issues/236): with the
+**Snacks Explorer** open (LazyVim's default file explorer), Claude's diff
+preview opens in the **wrong window** — it targets/corrupts the explorer sidebar
+instead of the main editor. Switching to neo-tree or setting
+`diff_opts.open_in_new_tab = true` avoids it.
+
+This fixture mirrors a LazyVim-style setup: `lazy.nvim` + `snacks.nvim` with the
+explorer enabled as a left sidebar, plus the local `claudecode.nvim` checkout
+(loaded via `dir`, so it also works from a git worktree).
+
+## Run it
+
+```bash
+source fixtures/nvim-aliases.sh
+cd fixtures/snacks-explorer/example   # so the explorer roots at some files
+vv snacks-explorer sample.txt
+```
+
+Inside Neovim:
+
+1. `:lua Snacks.explorer()` (or `<leader>e`) to open the explorer sidebar.
+2. Start Claude and ask it to **create a new file** or **edit a file that is not
+   already open in a window** — e.g. "create `notes.md` with a few lines".
+3. Observe the diff: the explorer sidebar gets hijacked / the diff lands in the
+   wrong split.
+
+## Reproduce the root cause without Claude
+
+The bug is entirely in window selection (`find_main_editor_window`), so you can
+prove it deterministically. With the explorer open and `sample.txt` in the
+editor:
+
+```vim
+:lua print(vim.bo[vim.api.nvim_win_get_buf(require('claudecode.diff')._find_main_editor_window())].filetype)
+```
+
+- **Buggy (before the fix):** prints `snacks_layout_box` — the explorer sidebar.
+- **Fixed:** prints the editor's filetype (e.g. `text`).
+
+### Why the explorer is mis-detected
+
+`Snacks.explorer()` (sidebar preset) is **not** a single floating window. It is:
+
+| window | filetype              | buftype  | floating? |
+| ------ | --------------------- | -------- | --------- |
+| box    | `snacks_layout_box`   | `nofile` | **no**    |
+| list   | `snacks_picker_list`  | `nofile` | yes       |
+| input  | `snacks_picker_input` | `prompt` | yes       |
+
+`find_main_editor_window` excluded `snacks_picker_list` (PR #165) but **not**
+`snacks_layout_box`. The layout box is a non-floating `nofile` split with an
+unrecognized filetype, so it passed every check and — being first in the window
+list — was returned as the "main editor window". The fix adds
+`snacks_layout_box` to the exclusion list.

--- a/fixtures/snacks-explorer/README.md
+++ b/fixtures/snacks-explorer/README.md
@@ -14,11 +14,11 @@ explorer enabled as a left sidebar, plus the local `claudecode.nvim` checkout
 
 ```bash
 source fixtures/nvim-aliases.sh
-cd fixtures/snacks-explorer/example   # so the explorer roots at some files
-vv snacks-explorer sample.txt
+# `vv` always cd's to the fixtures/ dir, so pass the file path relative to it.
+vv snacks-explorer snacks-explorer/example/sample.txt
 ```
 
-Inside Neovim:
+Inside Neovim (the explorer roots at the `fixtures/` dir — `example/` is in it):
 
 1. `:lua Snacks.explorer()` (or `<leader>e`) to open the explorer sidebar.
 2. Start Claude and ask it to **create a new file** or **edit a file that is not

--- a/fixtures/snacks-explorer/example/README.md
+++ b/fixtures/snacks-explorer/example/README.md
@@ -1,0 +1,3 @@
+# Example
+
+A second file.

--- a/fixtures/snacks-explorer/example/sample.txt
+++ b/fixtures/snacks-explorer/example/sample.txt
@@ -1,0 +1,5 @@
+line one
+line two
+line three
+line four
+line five

--- a/fixtures/snacks-explorer/init.lua
+++ b/fixtures/snacks-explorer/init.lua
@@ -1,0 +1,1 @@
+require("config.lazy")

--- a/fixtures/snacks-explorer/lazy-lock.json
+++ b/fixtures/snacks-explorer/lazy-lock.json
@@ -1,0 +1,5 @@
+{
+  "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
+  "snacks.nvim": { "branch": "main", "commit": "882c996cf28183f4d63640de0b4c02ec886d01f2" },
+  "tokyonight.nvim": { "branch": "main", "commit": "cdc07ac78467a233fd62c493de29a17e0cf2b2b6" }
+}

--- a/fixtures/snacks-explorer/lua/config/lazy.lua
+++ b/fixtures/snacks-explorer/lua/config/lazy.lua
@@ -1,0 +1,37 @@
+-- Bootstrap lazy.nvim
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not (vim.uv or vim.loop).fs_stat(lazypath) then
+  local lazyrepo = "https://github.com/folke/lazy.nvim.git"
+  local out = vim.fn.system({ "git", "clone", "--filter=blob:none", "--branch=stable", lazyrepo, lazypath })
+  if vim.v.shell_error ~= 0 then
+    vim.api.nvim_echo({
+      { "Failed to clone lazy.nvim:\n", "ErrorMsg" },
+      { out, "WarningMsg" },
+      { "\nPress any key to exit..." },
+    }, true, {})
+    vim.fn.getchar()
+    os.exit(1)
+  end
+end
+vim.opt.rtp:prepend(lazypath)
+
+vim.g.mapleader = " "
+vim.g.maplocalleader = "\\"
+
+-- Resolve the claudecode.nvim checkout that owns this fixture.
+-- XDG_CONFIG_HOME is set to the `fixtures/` dir by the `vv` launcher, so the
+-- repository root is its parent. This makes the fixture load the local plugin
+-- copy (including git worktrees) without relying on lazy's default dev path.
+local repo_root = vim.fn.fnamemodify(vim.env.XDG_CONFIG_HOME or vim.fn.getcwd(), ":h")
+vim.g.claudecode_dev_dir = repo_root
+
+require("lazy").setup({
+  spec = {
+    { import = "plugins" },
+  },
+  install = { colorscheme = { "habamax" } },
+  checker = { enabled = false },
+})
+
+vim.keymap.set("n", "<leader>l", "<cmd>Lazy<cr>", { desc = "Lazy Plugin Manager" })
+vim.keymap.set("t", "<Esc><Esc>", "<C-\\><C-n>", { desc = "Exit terminal mode (double esc)" })

--- a/fixtures/snacks-explorer/lua/plugins/dev-claudecode.lua
+++ b/fixtures/snacks-explorer/lua/plugins/dev-claudecode.lua
@@ -1,0 +1,26 @@
+-- Development configuration for claudecode.nvim with Snacks Explorer.
+-- Loads the local plugin checkout (resolved in lua/config/lazy.lua) via `dir`
+-- so it works from a normal checkout or a git worktree.
+return {
+  "coder/claudecode.nvim",
+  dir = vim.g.claudecode_dev_dir,
+  dependencies = { "folke/snacks.nvim" },
+  keys = {
+    { "<leader>a", nil, desc = "AI/Claude Code" },
+    { "<leader>ac", "<cmd>ClaudeCode<cr>", desc = "Toggle Claude" },
+    { "<leader>af", "<cmd>ClaudeCodeFocus<cr>", desc = "Focus Claude" },
+    { "<leader>as", "<cmd>ClaudeCodeAdd %<cr>", mode = "n", desc = "Add current buffer" },
+    { "<leader>as", "<cmd>ClaudeCodeSend<cr>", mode = "v", desc = "Send to Claude" },
+    { "<leader>ao", "<cmd>ClaudeCodeOpen<cr>", desc = "Open Claude" },
+    { "<leader>aq", "<cmd>ClaudeCodeClose<cr>", desc = "Close Claude" },
+    { "<leader>aS", "<cmd>ClaudeCodeStart<cr>", desc = "Start Claude Server" },
+    { "<leader>aQ", "<cmd>ClaudeCodeStop<cr>", desc = "Stop Claude Server" },
+    { "<leader>aa", "<cmd>ClaudeCodeDiffAccept<cr>", desc = "Accept diff" },
+    { "<leader>ad", "<cmd>ClaudeCodeDiffDeny<cr>", desc = "Deny diff" },
+  },
+  ---@type PartialClaudeCodeConfig
+  opts = {
+    -- Keep server manual/predictable for reproduction; tests start it explicitly.
+    log_level = "debug",
+  },
+}

--- a/fixtures/snacks-explorer/lua/plugins/init.lua
+++ b/fixtures/snacks-explorer/lua/plugins/init.lua
@@ -1,0 +1,11 @@
+-- Basic plugin configuration
+return {
+  {
+    "folke/tokyonight.nvim",
+    lazy = false,
+    priority = 1000,
+    config = function()
+      vim.cmd([[colorscheme tokyonight]])
+    end,
+  },
+}

--- a/fixtures/snacks-explorer/lua/plugins/snacks.lua
+++ b/fixtures/snacks-explorer/lua/plugins/snacks.lua
@@ -1,0 +1,30 @@
+-- Snacks Explorer (LazyVim's default file explorer) reproduction fixture.
+-- The explorer sidebar is what issue #236 reports the diff incorrectly opening into.
+return {
+  "folke/snacks.nvim",
+  priority = 1000,
+  lazy = false,
+  ---@type snacks.Config
+  opts = {
+    explorer = { enabled = true },
+    picker = {
+      enabled = true,
+      sources = {
+        explorer = {
+          -- Match LazyVim defaults: left sidebar, auto-close disabled so it
+          -- stays open like a tree explorer.
+          layout = { preset = "sidebar", preview = false },
+        },
+      },
+    },
+  },
+  keys = {
+    {
+      "<leader>e",
+      function()
+        Snacks.explorer()
+      end,
+      desc = "Snacks Explorer",
+    },
+  },
+}

--- a/lua/claudecode/diff.lua
+++ b/lua/claudecode/diff.lua
@@ -74,6 +74,7 @@ local function find_main_editor_window()
         or filetype == "aerial"
         or filetype == "tagbar"
         or filetype == "snacks_picker_list"
+        or filetype == "snacks_layout_box"
       )
     then
       is_suitable = false
@@ -86,6 +87,9 @@ local function find_main_editor_window()
 
   return nil
 end
+
+-- Exposed for testing the sidebar/explorer exclusion logic.
+M._find_main_editor_window = find_main_editor_window
 
 ---Find the Claude Code terminal window to keep focus there.
 ---Uses the terminal provider to get the active terminal buffer, then finds its window.
@@ -933,7 +937,13 @@ function M._create_diff_view_from_window(
       local buftype = vim.api.nvim_buf_get_option(buf, "buftype")
       local filetype = vim.api.nvim_buf_get_option(buf, "filetype")
 
-      if buftype == "terminal" or buftype == "prompt" or filetype == "neo-tree" or filetype == "snacks_picker_list" then
+      if
+        buftype == "terminal"
+        or buftype == "prompt"
+        or filetype == "neo-tree"
+        or filetype == "snacks_picker_list"
+        or filetype == "snacks_layout_box"
+      then
         create_split()
       end
 

--- a/tests/unit/diff_find_main_editor_window_spec.lua
+++ b/tests/unit/diff_find_main_editor_window_spec.lua
@@ -1,0 +1,109 @@
+-- Regression coverage for find_main_editor_window's sidebar/explorer exclusion.
+--
+-- Issue #236: the Snacks Explorer (LazyVim default) renders its sidebar as a
+-- NON-floating split window with filetype "snacks_layout_box" (buftype
+-- "nofile"); its picker list/input float on top. find_main_editor_window must
+-- skip the layout box so Claude's diffs open in the real editor window instead
+-- of corrupting the explorer sidebar.
+require("tests.busted_setup")
+
+describe("diff.find_main_editor_window sidebar exclusion", function()
+  local diff
+  local saved
+
+  -- Build a fake window layout and stub the four vim.api calls the function uses.
+  -- `wins` is an ordered list of { ft=, bt=, floating= } describing each window.
+  local function with_layout(wins)
+    local win_ids, buf_of, opt_of, cfg_of = {}, {}, {}, {}
+    for i, w in ipairs(wins) do
+      local win_id = 1000 + i
+      local buf_id = 2000 + i
+      win_ids[i] = win_id
+      buf_of[win_id] = buf_id
+      opt_of[buf_id] = { buftype = w.bt or "", filetype = w.ft or "" }
+      cfg_of[win_id] = { relative = w.floating and "editor" or "" }
+    end
+
+    _G.vim.api.nvim_list_wins = function()
+      return win_ids
+    end
+    _G.vim.api.nvim_win_get_buf = function(win)
+      return buf_of[win]
+    end
+    _G.vim.api.nvim_buf_get_option = function(buf, name)
+      return opt_of[buf][name]
+    end
+    _G.vim.api.nvim_win_get_config = function(win)
+      return cfg_of[win]
+    end
+
+    return win_ids
+  end
+
+  before_each(function()
+    saved = {
+      nvim_list_wins = _G.vim.api.nvim_list_wins,
+      nvim_win_get_buf = _G.vim.api.nvim_win_get_buf,
+      nvim_buf_get_option = _G.vim.api.nvim_buf_get_option,
+      nvim_win_get_config = _G.vim.api.nvim_win_get_config,
+    }
+    package.loaded["claudecode.diff"] = nil
+    diff = require("claudecode.diff")
+  end)
+
+  after_each(function()
+    for name, fn in pairs(saved) do
+      _G.vim.api[name] = fn
+    end
+    package.loaded["claudecode.diff"] = nil
+  end)
+
+  it("skips the Snacks Explorer layout box and returns the real editor (issue #236)", function()
+    -- Snacks Explorer sidebar is window 1, the real editor is window 2.
+    local wins = with_layout({
+      { ft = "snacks_layout_box", bt = "nofile" }, -- explorer container (non-floating split)
+      { ft = "lua", bt = "" }, -- the actual editor
+    })
+
+    expect(diff._find_main_editor_window()).to_be(wins[2])
+  end)
+
+  it("skips snacks_picker_list sidebars (regression for #165)", function()
+    local wins = with_layout({
+      { ft = "snacks_picker_list", bt = "nofile" },
+      { ft = "lua", bt = "" },
+    })
+
+    expect(diff._find_main_editor_window()).to_be(wins[2])
+  end)
+
+  it("skips common file-explorer and outline sidebars", function()
+    for _, ft in ipairs({ "neo-tree", "NvimTree", "oil", "minifiles", "netrw", "aerial", "tagbar" }) do
+      local wins = with_layout({
+        { ft = ft, bt = "" },
+        { ft = "text", bt = "" },
+      })
+      expect(diff._find_main_editor_window()).to_be(wins[2])
+    end
+  end)
+
+  it("skips terminal, prompt, and floating windows", function()
+    local wins = with_layout({
+      { ft = "", bt = "terminal" }, -- Claude terminal
+      { ft = "", bt = "prompt" }, -- picker input
+      { ft = "lua", bt = "", floating = true }, -- floating window
+      { ft = "go", bt = "" }, -- the actual editor
+    })
+
+    expect(diff._find_main_editor_window()).to_be(wins[4])
+  end)
+
+  it("returns nil when only excluded windows exist", function()
+    with_layout({
+      { ft = "snacks_layout_box", bt = "nofile" },
+      { ft = "", bt = "terminal" },
+    })
+
+    expect(diff._find_main_editor_window()).to_be(nil)
+  end)
+end)


### PR DESCRIPTION
## Summary

Fixes #236. With the **Snacks Explorer** sidebar open (LazyVim's default file explorer), Claude's diff preview opens **into / on top of the explorer window** instead of the main editor — corrupting the explorer (its list window gets flipped into `diff` mode) and misplacing the diff. This is the "glitchy diff UI" the issue reports. neo-tree is unaffected, and `diff_opts.open_in_new_tab = true` sidesteps it.

## Root cause

`Snacks.explorer()` (sidebar preset) is **not a single floating window** — it's three windows:

| window | filetype | buftype | floating? |
|--------|----------|---------|-----------|
| box | `snacks_layout_box` | `nofile` | **no (a real split)** |
| list | `snacks_picker_list` | `nofile` | yes |
| input | `snacks_picker_input` | `prompt` | yes |

`find_main_editor_window()` (`lua/claudecode/diff.lua`) returns the first window that is not floating, not a terminal/prompt buftype, and not in its filetype exclusion list. That list already excluded `snacks_picker_list` (#165) but **not `snacks_layout_box`**. The layout box is a non-floating `nofile` split with an unrecognized filetype, so it passes every guard and — being first in `nvim_list_wins()` — is returned as the "main editor window."

`open_diff_blocking` only avoids `find_main_editor_window()` when the edited file is already visible in a window (it reuses that window). Otherwise — **a brand-new file, or any file not currently open** — it falls back to the layout box, and `choose_original_window()` then reuses/splits the explorer sidebar because the box buffer has an empty name and is unmodified.

This also explains the known workarounds: `open_in_new_tab = true` takes a branch that never calls `find_main_editor_window()`, and neo-tree's sidebar (`filetype == "neo-tree"`) was already in the exclusion list.

## Fix

Add `snacks_layout_box` to the exclusion list in `find_main_editor_window()` and to the equivalent inline guard in `_create_diff_view_from_window()`. The layout box is always explorer chrome, never an edit target, so excluding it is unconditionally correct (and the floating-preset case was already covered by the floating-window check).

## Reproduction

Adds a LazyVim-style fixture `fixtures/snacks-explorer/` (`lazy.nvim` + `snacks.nvim` explorer + local `claudecode.nvim`):

```bash
source fixtures/nvim-aliases.sh
cd fixtures/snacks-explorer/example
vv snacks-explorer sample.txt
```

Then `:lua Snacks.explorer()` and ask Claude to create a new file / edit a file not currently open.

Deterministic proof (no Claude needed), with the explorer open and `sample.txt` in the editor:

```vim
:lua print(vim.bo[vim.api.nvim_win_get_buf(require('claudecode.diff')._find_main_editor_window())].filetype)
```

- **before:** `snacks_layout_box` (the explorer sidebar — wrong)
- **after:** `text` (the real editor — correct)

New-file diff window layout **before** the fix (note `diff:true` on the explorer's `snacks_picker_list`):

```
{ft:"snacks_layout_box",  col:0,   diff:false}
{ft:"snacks_picker_list", col:0,   diff:true }   ← explorer list corrupted
{ft:"snacks_picker_input",col:0,   diff:false}
{ft:"text", name:"sample.txt", col:41, diff:false}
{ft:"text", name:"newfile-diff (NEW FILE - proposed)", col:121, diff:true}
```

…and **after** (explorer untouched; clean two-pane diff in the editor area):

```
{ft:"snacks_layout_box",  col:0,   diff:false}
{ft:"snacks_picker_list", col:0,   diff:false}   ← explorer intact
{ft:"snacks_picker_input",col:0,   diff:false}
{ft:"text", name:"sample.txt", col:41, diff:false}
{ft:"", name:"brand_new.txt (NEW FILE)",               col:94,  diff:true}
{ft:"text", name:"newfile-diff (NEW FILE - proposed)", col:147, diff:true}
```

## Tests

Adds `tests/unit/diff_find_main_editor_window_spec.lua` — the first coverage for this function. It asserts the layout box is skipped (this bug), the picker list is skipped (regression for #165), other sidebars/terminals/prompts/floats are skipped, and the all-excluded case returns `nil`.

`mise run all` passes locally (luacheck clean; full suite green).


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
