### PR TITLE
docs(readme): add cmd triggers to lazy.nvim spec so :ClaudeCode loads on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,26 @@ When Anthropic released Claude Code, they only supported VS Code and JetBrains. 
   "coder/claudecode.nvim",
   dependencies = { "folke/snacks.nvim" },
   config = true,
+  -- `cmd` lets lazy.nvim create command stubs that load the plugin on first use,
+  -- so `:ClaudeCode` and friends work on a fresh start. Without it, a keys-only
+  -- spec defers loading until a <leader>a* mapping is pressed and the commands
+  -- would not exist yet.
+  cmd = {
+    "ClaudeCode",
+    "ClaudeCodeFocus",
+    "ClaudeCodeSelectModel",
+    "ClaudeCodeAdd",
+    "ClaudeCodeSend",
+    "ClaudeCodeTreeAdd",
+    "ClaudeCodeStatus",
+    "ClaudeCodeStart",
+    "ClaudeCodeStop",
+    "ClaudeCodeOpen",
+    "ClaudeCodeClose",
+    "ClaudeCodeDiffAccept",
+    "ClaudeCodeDiffDeny",
+    "ClaudeCodeCloseAllDiffs",
+  },
   keys = {
     { "<leader>a", nil, desc = "AI/Claude Code" },
     { "<leader>ac", "<cmd>ClaudeCode<cr>", desc = "Toggle Claude" },
@@ -50,6 +70,12 @@ When Anthropic released Claude Code, they only supported VS Code and JetBrains. 
 ```
 
 That's it! The plugin will auto-configure everything else.
+
+> **Lazy-loading:** with this spec the plugin loads on first use — when a listed
+> `cmd` is run or a mapped key is pressed — not at startup. The `cmd` list is what
+> makes `:ClaudeCode` (and the other commands below) available before any keymap is
+> pressed. If you would rather load the plugin eagerly at startup, set `lazy = false`
+> (the `cmd`/`keys` triggers then become optional).
 
 ## Requirements
 
@@ -96,6 +122,8 @@ If you have a local installation, configure the plugin with the direct path:
     terminal_cmd = "~/.claude/local/claude", -- Point to local installation
   },
   config = true,
+  -- Also copy the `cmd = { ... }` list from the Installation section above so the
+  -- :ClaudeCode* commands load without having to press a key first.
   keys = {
     -- Your keymaps here
   },
@@ -153,6 +181,8 @@ Configure the plugin with the detected path:
     terminal_cmd = "/path/to/your/claude", -- Use output from 'which claude'
   },
   config = true,
+  -- Also copy the `cmd = { ... }` list from the Installation section above so the
+  -- :ClaudeCode* commands load without having to press a key first.
   keys = {
     -- Your keymaps here
   },

--- a/dev-config.lua
+++ b/dev-config.lua
@@ -6,6 +6,25 @@
 return {
   "coder/claudecode.nvim",
   dev = true, -- Use local development version
+  -- `cmd` lets lazy.nvim create command stubs that load the plugin on first use,
+  -- so `:ClaudeCode` and friends work on a fresh start (a keys-only spec defers
+  -- loading until a <leader>a* mapping is pressed).
+  cmd = {
+    "ClaudeCode",
+    "ClaudeCodeFocus",
+    "ClaudeCodeSelectModel",
+    "ClaudeCodeAdd",
+    "ClaudeCodeSend",
+    "ClaudeCodeTreeAdd",
+    "ClaudeCodeStatus",
+    "ClaudeCodeStart",
+    "ClaudeCodeStop",
+    "ClaudeCodeOpen",
+    "ClaudeCodeClose",
+    "ClaudeCodeDiffAccept",
+    "ClaudeCodeDiffDeny",
+    "ClaudeCodeCloseAllDiffs",
+  },
   keys = {
     -- AI/Claude Code prefix
     { "<leader>a", nil, desc = "AI/Claude Code" },


### PR DESCRIPTION
> [!NOTE]
> This change was prepared with the assistance of Claude Code.

## Problem

The README's recommended lazy.nvim install spec lazy-loads the plugin via `keys` **only** (with `config = true`, no `cmd`). Per lazy.nvim semantics, declaring `keys` implies `lazy = true`, so `plugin/claudecode.lua` is not sourced and `require("claudecode").setup()` never runs at startup. Because every `:ClaudeCode*` command is registered inside `setup()` → `M._create_commands()` (`lua/claudecode/init.lua:527`), and lazy's `keys` handler creates only key-mapping stubs (not command stubs), `:ClaudeCode` is genuinely undefined on a fresh Neovim (`E492`) until a `<leader>a*` mapping is pressed.

This contradicts the README's own *Quick Demo*, *Usage*, and *Key Commands* sections, which all instruct users to run `:ClaudeCode` directly — so users who follow the docs literally conclude the plugin "doesn't load". This has been reported more than once (#239, and the earlier #128).

## Fix

Add a `cmd = { … }` array (listing the user-facing commands) to the install spec. lazy.nvim then creates command stubs that load the plugin on first invocation, so `:ClaudeCode` and friends work from a cold start **without** forcing an eager startup load — lazy-loading is preserved.

This is the minimal, idiomatic resolution and matches the conclusion already reached in #128. It is consistent with prior art among command-exposing Neovim plugins that lazy-load (e.g. `copilot.lua` ships `cmd = "Copilot"`; the LazyVim avante extra ships an explicit `cmd = { … }` array alongside its keys).

## Changes

- **`README.md`**
  - Primary Installation spec: added the `cmd` array (all 14 commands) with an explanatory comment.
  - Added a short *Lazy-loading* note after the install block, mentioning the `lazy = false` alternative for eager loading.
  - Local-installation and native-binary snippets: added a one-line hint to also copy the `cmd` list.
- **`dev-config.lua`**: added the same `cmd` array so the maintainer dev config dogfoods the fix.

No runtime/source code changed; the command-registration architecture is correct lazy.nvim behavior. `mise run format` and `mise run check` pass.

## Verification

Reproduced and verified with two fixtures mirroring the README spec (keys-only vs. keys + `cmd`), via a deterministic headless check of `vim.fn.exists(":ClaudeCode")`:

| Spec | cold start | after invoking a command |
| --- | --- | --- |
| keys-only (old) | `exists=0`, not loaded — `E492` | never loads from a command |
| keys + `cmd` (this PR) | `exists=2` (stub) | loads on demand, command runs |

Full triage and reproduction details: #239.

Closes #239.
Related to #128 (earlier duplicate).
