### PR TITLE
Fix IDE tool response handling

### DIFF
--- a/lua/claudecode/server/init.lua
+++ b/lua/claudecode/server/init.lua
@@ -282,7 +282,6 @@ function M.register_handlers()
         capabilities = {
           logging = vim.empty_dict(), -- Ensure this is an object {} not an array []
           prompts = { listChanged = true },
-          resources = { subscribe = true, listChanged = true },
           tools = { listChanged = true },
         },
         serverInfo = {

--- a/lua/claudecode/tools/check_document_dirty.lua
+++ b/lua/claudecode/tools/check_document_dirty.lua
@@ -36,7 +36,7 @@ local function handler(params)
           text = vim.json.encode({
             success = false,
             message = "Document not open: " .. params.filePath,
-          }, { indent = 2 }),
+          }),
         },
       },
     }
@@ -55,7 +55,7 @@ local function handler(params)
           filePath = params.filePath,
           isDirty = is_dirty,
           isUntitled = is_untitled,
-        }, { indent = 2 }),
+        }),
       },
     },
   }

--- a/lua/claudecode/tools/get_current_selection.lua
+++ b/lua/claudecode/tools/get_current_selection.lua
@@ -14,7 +14,7 @@ local schema = {
 ---@param error_context string A description of what failed for error messages
 ---@return string The JSON-encoded string
 local function safe_json_encode(data, error_context)
-  local ok, encoded = pcall(vim.json.encode, data, { indent = 2 })
+  local ok, encoded = pcall(vim.json.encode, data)
   if not ok then
     error({
       code = -32000,

--- a/lua/claudecode/tools/get_diagnostics.lua
+++ b/lua/claudecode/tools/get_diagnostics.lua
@@ -1,9 +1,5 @@
 --- Tool implementation for getting diagnostics.
 
--- NOTE: Its important we don't tip off Claude that we're dealing with Neovim LSP diagnostics because it may adjust
--- line and col numbers by 1 on its own (since it knows nvim LSP diagnostics are 0-indexed). By calling these
--- "editor diagnostics" and converting to 1-indexed ourselves we (hopefully) avoid incorrect line and column numbers
--- in Claude's responses.
 local schema = {
   description = "Get language diagnostics (errors, warnings) from the editor",
   inputSchema = {
@@ -19,14 +15,81 @@ local schema = {
   },
 }
 
+local severity_names = {
+  [1] = "Error",
+  [2] = "Warning",
+  [3] = "Info",
+  [4] = "Hint",
+}
+
+local function starts_with(str, prefix)
+  return type(str) == "string" and str:sub(1, #prefix) == prefix
+end
+
+local function path_to_uri(path)
+  if vim.uri_from_fname then
+    return vim.uri_from_fname(path)
+  end
+  return "file://" .. path
+end
+
+local function severity_name(severity)
+  if type(severity) == "string" then
+    return severity
+  end
+  return severity_names[severity] or "Info"
+end
+
+local function diagnostic_range(diagnostic)
+  local start_line = diagnostic.lnum or 0
+  local start_col = diagnostic.col or 0
+  local end_line = diagnostic.end_lnum or start_line
+  local end_col = diagnostic.end_col or (start_col + 1)
+
+  return {
+    start = { line = start_line, character = start_col },
+    ["end"] = { line = end_line, character = end_col },
+  }
+end
+
+local function get_diagnostic_path(diagnostic, fallback_path)
+  if diagnostic.bufnr then
+    local file_path = vim.api.nvim_buf_get_name(diagnostic.bufnr)
+    if file_path and file_path ~= "" then
+      return file_path
+    end
+  end
+  return fallback_path
+end
+
+local function append_diagnostic(files, file_by_uri, file_path, diagnostic)
+  if not file_path or file_path == "" then
+    return
+  end
+
+  local uri = path_to_uri(file_path)
+  local file = file_by_uri[uri]
+  if not file then
+    file = { uri = uri, diagnostics = {} }
+    file_by_uri[uri] = file
+    table.insert(files, file)
+  end
+
+  table.insert(file.diagnostics, {
+    message = diagnostic.message or "",
+    severity = severity_name(diagnostic.severity),
+    range = diagnostic_range(diagnostic),
+    source = diagnostic.source,
+    code = diagnostic.code and tostring(diagnostic.code) or nil,
+  })
+end
+
 ---Handles the getDiagnostics tool invocation.
 ---Retrieves diagnostics from Neovim's diagnostic system.
 ---@param params table The input parameters for the tool
 ---@return table diagnostics MCP-compliant response with diagnostics data
 local function handler(params)
   if not vim.lsp or not vim.diagnostic or not vim.diagnostic.get then
-    -- Returning an empty list or a specific status could be an alternative.
-    -- For now, let's align with the error pattern for consistency if the feature is unavailable.
     error({
       code = -32000,
       message = "Feature unavailable",
@@ -38,58 +101,44 @@ local function handler(params)
 
   logger.debug("getDiagnostics handler called with params: " .. vim.inspect(params))
 
-  -- Extract the uri parameter
   local diagnostics
+  local fallback_path
 
   if not params.uri then
-    -- Get diagnostics for all buffers
     logger.debug("Getting diagnostics for all open buffers")
     diagnostics = vim.diagnostic.get(nil)
   else
     local uri = params.uri
-    local filepath = vim.startswith(uri, "file://") and vim.uri_to_fname(uri) or uri
+    fallback_path = starts_with(uri, "file://") and vim.uri_to_fname(uri) or uri
 
-    -- Get buffer number for the specific file
-    local bufnr = vim.fn.bufnr(filepath)
+    local bufnr = vim.fn.bufnr(fallback_path)
     if bufnr == -1 then
-      -- File is not open in any buffer, throw an error
-      logger.debug("File buffer must be open to get diagnostics: " .. filepath)
+      logger.debug("File buffer must be open to get diagnostics: " .. fallback_path)
       error({
         code = -32001,
         message = "File not open",
-        data = "File must be open to retrieve diagnostics: " .. filepath,
+        data = "File must be open to retrieve diagnostics: " .. fallback_path,
       })
-    else
-      -- Get diagnostics for the specific buffer
-      logger.debug("Getting diagnostics for bufnr: " .. bufnr)
-      diagnostics = vim.diagnostic.get(bufnr)
     end
+
+    logger.debug("Getting diagnostics for bufnr: " .. bufnr)
+    diagnostics = vim.diagnostic.get(bufnr)
   end
 
-  local formatted_diagnostics = {}
-  for _, diagnostic in ipairs(diagnostics) do
-    local file_path = vim.api.nvim_buf_get_name(diagnostic.bufnr)
-    -- Ensure we only include diagnostics with valid file paths
-    if file_path and file_path ~= "" then
-      table.insert(formatted_diagnostics, {
-        type = "text",
-        -- json encode this
-        text = vim.json.encode({
-          -- Use the file path and diagnostic information
-          filePath = file_path,
-          -- Convert line and column to 1-indexed
-          line = diagnostic.lnum + 1,
-          character = diagnostic.col + 1,
-          severity = diagnostic.severity, -- e.g., vim.diagnostic.severity.ERROR
-          message = diagnostic.message,
-          source = diagnostic.source,
-        }),
-      })
-    end
+  local files = {}
+  local file_by_uri = {}
+
+  for _, diagnostic in ipairs(diagnostics or {}) do
+    append_diagnostic(files, file_by_uri, get_diagnostic_path(diagnostic, fallback_path), diagnostic)
   end
 
   return {
-    content = formatted_diagnostics,
+    content = {
+      {
+        type = "text",
+        text = vim.json.encode(files),
+      },
+    },
   }
 end
 

--- a/lua/claudecode/tools/get_latest_selection.lua
+++ b/lua/claudecode/tools/get_latest_selection.lua
@@ -30,7 +30,7 @@ local function handler(params)
           text = vim.json.encode({
             success = false,
             message = "No selection available",
-          }, { indent = 2 }),
+          }),
         },
       },
     }
@@ -41,7 +41,7 @@ local function handler(params)
     content = {
       {
         type = "text",
-        text = vim.json.encode(selection, { indent = 2 }),
+        text = vim.json.encode(selection),
       },
     },
   }

--- a/lua/claudecode/tools/get_open_editors.lua
+++ b/lua/claudecode/tools/get_open_editors.lua
@@ -105,7 +105,7 @@ local function handler(params)
     content = {
       {
         type = "text",
-        text = vim.json.encode({ tabs = tabs }, { indent = 2 }),
+        text = vim.json.encode({ tabs = tabs }),
       },
     },
   }

--- a/lua/claudecode/tools/get_workspace_folders.lua
+++ b/lua/claudecode/tools/get_workspace_folders.lua
@@ -55,7 +55,7 @@ local function handler(params)
           success = true,
           folders = folders,
           rootPath = cwd,
-        }, { indent = 2 }),
+        }),
       },
     },
   }

--- a/lua/claudecode/tools/open_file.lua
+++ b/lua/claudecode/tools/open_file.lua
@@ -118,6 +118,8 @@ local function handler(params)
   local preview = params.preview or false
   local make_frontmost = params.makeFrontmost ~= false -- default true
   local select_to_end_of_line = params.selectToEndOfLine or false
+  local start_text = type(params.startText) == "string" and params.startText ~= "" and params.startText or nil
+  local end_text = type(params.endText) == "string" and params.endText ~= "" and params.endText or nil
 
   local message = "Opened file: " .. file_path
 
@@ -156,87 +158,95 @@ local function handler(params)
     else
       vim.cmd("edit " .. vim.fn.fnameescape(file_path))
     end
+    target_win = vim.api.nvim_get_current_win()
+  end
+
+  local function run_in_target_window(callback)
+    if target_win then
+      return vim.api.nvim_win_call(target_win, callback)
+    end
+    return callback()
   end
 
   -- Handle text selection by line numbers
   if params.startLine or params.endLine then
-    local start_line = params.startLine or 1
-    local end_line = params.endLine or start_line
+    run_in_target_window(function()
+      local start_line = params.startLine or 1
+      local end_line = params.endLine or start_line
 
-    -- Convert to 0-based indexing for vim API
-    local start_pos = { start_line - 1, 0 }
-    local end_pos = { end_line - 1, -1 } -- -1 means end of line
+      -- Convert to 0-based indexing for vim API
+      local start_pos = { start_line - 1, 0 }
+      local end_pos = { end_line - 1, -1 } -- -1 means end of line
 
-    vim.api.nvim_buf_set_mark(0, "<", start_pos[1], start_pos[2], {})
-    vim.api.nvim_buf_set_mark(0, ">", end_pos[1], end_pos[2], {})
-    vim.cmd("normal! gv")
+      vim.api.nvim_buf_set_mark(0, "<", start_pos[1], start_pos[2], {})
+      vim.api.nvim_buf_set_mark(0, ">", end_pos[1], end_pos[2], {})
+      vim.cmd("normal! gv")
 
-    message = "Opened file and selected lines " .. start_line .. " to " .. end_line
+      message = "Opened file and selected lines " .. start_line .. " to " .. end_line
+    end)
   end
 
   -- Handle text pattern selection
-  if params.startText then
-    local buf = vim.api.nvim_get_current_buf()
-    local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-    local start_line_idx, start_col_idx
-    local end_line_idx, end_col_idx
+  if start_text then
+    run_in_target_window(function()
+      local buf = vim.api.nvim_get_current_buf()
+      local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+      local start_line_idx, start_col_idx
+      local end_line_idx, end_col_idx
 
-    -- Find start text
-    for line_idx, line in ipairs(lines) do
-      local col_idx = string.find(line, params.startText, 1, true) -- plain text search
-      if col_idx then
-        start_line_idx = line_idx - 1 -- Convert to 0-based
-        start_col_idx = col_idx - 1 -- Convert to 0-based
-        break
+      -- Find start text
+      for line_idx, line in ipairs(lines) do
+        local col_idx = string.find(line, start_text, 1, true) -- plain text search
+        if col_idx then
+          start_line_idx = line_idx - 1 -- Convert to 0-based
+          start_col_idx = col_idx - 1 -- Convert to 0-based
+          break
+        end
       end
-    end
 
-    if start_line_idx then
-      -- Find end text if provided
-      if params.endText then
-        for line_idx = start_line_idx + 1, #lines do
-          local line = lines[line_idx] -- Access current line directly
-          if line then
-            local col_idx = string.find(line, params.endText, 1, true)
-            if col_idx then
-              end_line_idx = line_idx
-              end_col_idx = col_idx + string.len(params.endText) - 1
-              if select_to_end_of_line then
-                end_col_idx = string.len(line)
+      if start_line_idx then
+        -- Find end text if provided
+        if end_text then
+          for line_idx = start_line_idx + 1, #lines do
+            local line = lines[line_idx] -- Access current line directly
+            if line then
+              local col_idx = string.find(line, end_text, 1, true)
+              if col_idx then
+                end_line_idx = line_idx
+                end_col_idx = col_idx + string.len(end_text) - 1
+                if select_to_end_of_line then
+                  end_col_idx = string.len(line)
+                end
+                break
               end
-              break
             end
           end
-        end
 
-        if end_line_idx then
-          message = 'Opened file and selected text from "' .. params.startText .. '" to "' .. params.endText .. '"'
+          if end_line_idx then
+            message = 'Opened file and selected text from "' .. start_text .. '" to "' .. end_text .. '"'
+          else
+            -- End text not found, select only start text
+            end_line_idx = start_line_idx
+            end_col_idx = start_col_idx + string.len(start_text) - 1
+            message = 'Opened file and positioned at "' .. start_text .. '" (end text "' .. end_text .. '" not found)'
+          end
         else
-          -- End text not found, select only start text
+          -- Only start text provided
           end_line_idx = start_line_idx
-          end_col_idx = start_col_idx + string.len(params.startText) - 1
-          message = 'Opened file and positioned at "'
-            .. params.startText
-            .. '" (end text "'
-            .. params.endText
-            .. '" not found)'
+          end_col_idx = start_col_idx + string.len(start_text) - 1
+          message = 'Opened file and selected text "' .. start_text .. '"'
         end
-      else
-        -- Only start text provided
-        end_line_idx = start_line_idx
-        end_col_idx = start_col_idx + string.len(params.startText) - 1
-        message = 'Opened file and selected text "' .. params.startText .. '"'
-      end
 
-      -- Apply the selection
-      vim.api.nvim_win_set_cursor(0, { start_line_idx + 1, start_col_idx })
-      vim.api.nvim_buf_set_mark(0, "<", start_line_idx, start_col_idx, {})
-      vim.api.nvim_buf_set_mark(0, ">", end_line_idx, end_col_idx, {})
-      vim.cmd("normal! gv")
-      vim.cmd("normal! zz") -- Center the selection in the window
-    else
-      message = 'Opened file, but text "' .. params.startText .. '" not found'
-    end
+        -- Apply the selection
+        vim.api.nvim_win_set_cursor(0, { start_line_idx + 1, start_col_idx })
+        vim.api.nvim_buf_set_mark(0, "<", start_line_idx, start_col_idx, {})
+        vim.api.nvim_buf_set_mark(0, ">", end_line_idx, end_col_idx, {})
+        vim.cmd("normal! gv")
+        vim.cmd("normal! zz") -- Center the selection in the window
+      else
+        message = 'Opened file, but text "' .. start_text .. '" not found'
+      end
+    end)
   end
 
   -- Return format based on makeFrontmost parameter
@@ -252,7 +262,7 @@ local function handler(params)
     }
   else
     -- Detailed JSON format when makeFrontmost=false
-    local buf = vim.api.nvim_get_current_buf()
+    local buf = target_win and vim.api.nvim_win_get_buf(target_win) or vim.api.nvim_get_current_buf()
     local detailed_info = {
       success = true,
       filePath = file_path,
@@ -264,7 +274,7 @@ local function handler(params)
       content = {
         {
           type = "text",
-          text = vim.json.encode(detailed_info, { indent = 2 }),
+          text = vim.json.encode(detailed_info),
         },
       },
     }

--- a/lua/claudecode/tools/save_document.lua
+++ b/lua/claudecode/tools/save_document.lua
@@ -40,7 +40,7 @@ local function handler(params)
           text = vim.json.encode({
             success = false,
             message = "Document not open: " .. params.filePath,
-          }, { indent = 2 }),
+          }),
         },
       },
     }
@@ -59,7 +59,7 @@ local function handler(params)
             success = false,
             message = "Failed to save file: " .. tostring(err),
             filePath = params.filePath,
-          }, { indent = 2 }),
+          }),
         },
       },
     }
@@ -75,7 +75,7 @@ local function handler(params)
           filePath = params.filePath,
           saved = true,
           message = "Document saved successfully",
-        }, { indent = 2 }),
+        }),
       },
     },
   }

--- a/tests/unit/server_spec.lua
+++ b/tests/unit/server_spec.lua
@@ -118,6 +118,21 @@ describe("WebSocket Server", function()
     expect(type(server.state.handlers["tools/list"])).to_be("function") -- Function, not table
   end)
 
+  it("should not advertise unsupported MCP resources", function()
+    server.register_handlers()
+
+    vim.empty_dict = vim.empty_dict or function()
+      return {}
+    end
+
+    local result = server.state.handlers["initialize"]({}, {})
+
+    expect(result).to_be_table()
+    expect(result.capabilities).to_be_table()
+    expect(result.capabilities.resources).to_be_nil()
+    expect(result.capabilities.tools).to_be_table()
+  end)
+
   it("should send message to client", function()
     -- Start server first
     local config = { port_range = { min = 10000, max = 65535 } }

--- a/tests/unit/tools/get_diagnostics_spec.lua
+++ b/tests/unit/tools/get_diagnostics_spec.lua
@@ -31,8 +31,9 @@ describe("Tool: get_diagnostics", function()
       return "/path/to/file_for_buf_" .. tostring(bufnr) .. ".lua"
     end)
     _G.vim.json.encode = spy.new(function(obj)
-      return vim.inspect(obj) -- Use vim.inspect as a simple serialization
+      return require("tests.busted_setup").json_encode(obj)
     end)
+    _G.vim.uri_from_fname = nil
     _G.vim.fn.bufnr = spy.new(function(filepath)
       -- Mock buffer lookup
       if filepath == "/test/file.lua" then
@@ -61,23 +62,38 @@ describe("Tool: get_diagnostics", function()
     _G.vim.json.encode = nil
     _G.vim.fn.bufnr = nil
     _G.vim.uri_to_fname = nil
+    _G.vim.uri_from_fname = nil
     _G.vim.startswith = nil
     -- Note: We don't nullify _G.vim.lsp or _G.vim.diagnostic entirely
     -- as they are checked for existence.
   end)
 
-  it("should return an empty list if no diagnostics are found", function()
+  it("should return an empty diagnostic file list if no diagnostics are found", function()
     local success, result = pcall(get_diagnostics_handler, {})
     expect(success).to_be_true()
     expect(result).to_be_table()
     expect(result.content).to_be_table()
-    expect(#result.content).to_be(0)
+    expect(#result.content).to_be(1)
+    expect(result.content[1].type).to_be("text")
+
+    local diagnostic_files = require("tests.busted_setup").json_decode(result.content[1].text)
+    expect(#diagnostic_files).to_be(0)
     assert.spy(_G.vim.diagnostic.get).was_called_with(nil)
   end)
 
-  it("should return formatted diagnostics if available", function()
+  it("should return diagnostics in Claude Code DiagnosticFile format", function()
     local mock_diagnostics = {
-      { bufnr = 1, lnum = 10, col = 5, severity = 1, message = "Error message 1", source = "linter1" },
+      {
+        bufnr = 1,
+        lnum = 10,
+        col = 5,
+        end_lnum = 10,
+        end_col = 12,
+        severity = 1,
+        message = "Error message 1",
+        source = "linter1",
+        code = 123,
+      },
       { bufnr = 2, lnum = 20, col = 15, severity = 2, message = "Warning message 2", source = "linter2" },
     }
     _G.vim.diagnostic.get = spy.new(function()
@@ -87,23 +103,26 @@ describe("Tool: get_diagnostics", function()
     local success, result = pcall(get_diagnostics_handler, {})
     expect(success).to_be_true()
     expect(result.content).to_be_table()
-    expect(#result.content).to_be(2)
-
-    -- Check that results are MCP content items
+    expect(#result.content).to_be(1)
     expect(result.content[1].type).to_be("text")
-    expect(result.content[2].type).to_be("text")
+    assert.spy(_G.vim.json.encode).was_called(1)
 
-    -- Verify JSON encoding was called with correct structure
-    assert.spy(_G.vim.json.encode).was_called(2)
+    local diagnostic_files = require("tests.busted_setup").json_decode(result.content[1].text)
+    expect(#diagnostic_files).to_be(2)
 
-    -- Check the first diagnostic was encoded with 1-indexed values
-    local first_call_args = _G.vim.json.encode.calls[1].vals[1]
-    expect(first_call_args.filePath).to_be("/path/to/file_for_buf_1.lua")
-    expect(first_call_args.line).to_be(11) -- 10 + 1 for 1-indexing
-    expect(first_call_args.character).to_be(6) -- 5 + 1 for 1-indexing
-    expect(first_call_args.severity).to_be(1)
-    expect(first_call_args.message).to_be("Error message 1")
-    expect(first_call_args.source).to_be("linter1")
+    expect(diagnostic_files[1].uri).to_be("file:///path/to/file_for_buf_1.lua")
+    expect(#diagnostic_files[1].diagnostics).to_be(1)
+    expect(diagnostic_files[1].diagnostics[1].message).to_be("Error message 1")
+    expect(diagnostic_files[1].diagnostics[1].severity).to_be("Error")
+    expect(diagnostic_files[1].diagnostics[1].range.start.line).to_be(10)
+    expect(diagnostic_files[1].diagnostics[1].range.start.character).to_be(5)
+    expect(diagnostic_files[1].diagnostics[1].range["end"].line).to_be(10)
+    expect(diagnostic_files[1].diagnostics[1].range["end"].character).to_be(12)
+    expect(diagnostic_files[1].diagnostics[1].source).to_be("linter1")
+    expect(diagnostic_files[1].diagnostics[1].code).to_be("123")
+
+    expect(diagnostic_files[2].uri).to_be("file:///path/to/file_for_buf_2.lua")
+    expect(diagnostic_files[2].diagnostics[1].severity).to_be("Warning")
 
     assert.spy(_G.vim.api.nvim_buf_get_name).was_called_with(1)
     assert.spy(_G.vim.api.nvim_buf_get_name).was_called_with(2)
@@ -131,10 +150,10 @@ describe("Tool: get_diagnostics", function()
     expect(success).to_be_true()
     expect(#result.content).to_be(1)
 
-    -- Verify only the diagnostic with a file path was included
-    assert.spy(_G.vim.json.encode).was_called(1)
-    local encoded_args = _G.vim.json.encode.calls[1].vals[1]
-    expect(encoded_args.filePath).to_be("/path/to/file1.lua")
+    local diagnostic_files = require("tests.busted_setup").json_decode(result.content[1].text)
+    expect(#diagnostic_files).to_be(1)
+    expect(diagnostic_files[1].uri).to_be("file:///path/to/file1.lua")
+    expect(#diagnostic_files[1].diagnostics).to_be(1)
   end)
 
   it("should error if vim.diagnostic.get is not available", function()
@@ -187,6 +206,11 @@ describe("Tool: get_diagnostics", function()
     local success, result = pcall(get_diagnostics_handler, { uri = "file:///test/file.lua" })
     expect(success).to_be_true()
     expect(#result.content).to_be(1)
+
+    local diagnostic_files = require("tests.busted_setup").json_decode(result.content[1].text)
+    expect(#diagnostic_files).to_be(1)
+    expect(diagnostic_files[1].uri).to_be("file:///test/file.lua")
+    expect(diagnostic_files[1].diagnostics[1].message).to_be("Error in file1")
 
     -- Should have used vim.uri_to_fname to convert URI to file path
     assert.spy(_G.vim.uri_to_fname).was_called_with("file:///test/file.lua")

--- a/tests/unit/tools/open_file_spec.lua
+++ b/tests/unit/tools/open_file_spec.lua
@@ -167,6 +167,54 @@ describe("Tool: open_file", function()
     expect(parsed_result.filePath).to_be("test.txt")
   end)
 
+  it("should ignore empty startText and endText from Claude Code", function()
+    local params = { filePath = "test.txt", makeFrontmost = false, startText = "", endText = "" }
+    local success, result = pcall(open_file_handler, params)
+
+    expect(success).to_be_true()
+    local parsed_result = require("tests.busted_setup").json_decode(result.content[1].text)
+    expect(parsed_result.success).to_be_true()
+    expect(parsed_result.filePath).to_be("test.txt")
+    expect(#_G.vim.cmd_history).to_be(1)
+    expect(_G.vim.cmd_history[1]).to_be("edit test.txt")
+  end)
+
+  it("should report details from the background target window", function()
+    _G.vim.api.nvim_list_wins = spy.new(function()
+      return { 2000 }
+    end)
+    _G.vim.api.nvim_win_get_buf = spy.new(function(win)
+      if win == 2000 then
+        return 20
+      end
+      return 99
+    end)
+    _G.vim.api.nvim_get_current_buf = spy.new(function()
+      return 99
+    end)
+    _G.vim.api.nvim_buf_get_option = spy.new(function(buf, option)
+      if option == "buftype" then
+        return ""
+      end
+      if option == "filetype" then
+        return buf == 20 and "lua" or "wrong"
+      end
+      return ""
+    end)
+    _G.vim.api.nvim_buf_line_count = spy.new(function(buf)
+      return buf == 20 and 42 or 1
+    end)
+
+    local params = { filePath = "test.txt", makeFrontmost = false }
+    local success, result = pcall(open_file_handler, params)
+
+    expect(success).to_be_true()
+    local parsed_result = require("tests.busted_setup").json_decode(result.content[1].text)
+    expect(parsed_result.languageId).to_be("lua")
+    expect(parsed_result.lineCount).to_be(42)
+    assert.spy(_G.vim.api.nvim_set_current_win).was_not_called()
+  end)
+
   it("should handle preview mode parameter", function()
     local params = { filePath = "test.txt", preview = true }
     local success, result = pcall(open_file_handler, params)


### PR DESCRIPTION
## Summary
- Update IDE diagnostic results to return grouped URI-based diagnostic payloads with editor-native ranges and severity names.
- Stop advertising an unsupported resources capability during initialization.
- Harden background file opens by ignoring empty text anchors, preserving focus, returning metadata from the target buffer, and serializing tool JSON compactly.

## Validation
- `mise exec -- stylua --check lua/claudecode/server/init.lua lua/claudecode/tools/check_document_dirty.lua lua/claudecode/tools/get_current_selection.lua lua/claudecode/tools/get_diagnostics.lua lua/claudecode/tools/get_latest_selection.lua lua/claudecode/tools/get_open_editors.lua lua/claudecode/tools/get_workspace_folders.lua lua/claudecode/tools/open_file.lua lua/claudecode/tools/save_document.lua tests/unit/server_spec.lua tests/unit/tools/get_diagnostics_spec.lua tests/unit/tools/open_file_spec.lua`
- `find lua -name '*.lua' -type f -print0 | xargs -0 -I{} mise exec -- luajit -e "assert(loadfile('{}'))"`
- `mise exec -- luacheck lua/ tests/ --no-unused-args --no-max-line-length`
- `mise exec -- busted -v <all test files>` — 643 successes / 0 failures / 0 errors / 0 pending
- Dogfooded in a real Neovim terminal session with an IDE protocol scenario; captured screenshot and recording artifacts for review.

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.5` • Thinking: `xhigh`_
