### PR TITLE
ci: auto-label new issues with needs-triage

### DIFF
--- a/.github/workflows/issue-triage.yaml
+++ b/.github/workflows/issue-triage.yaml
@@ -1,0 +1,20 @@
+name: Issue Triage
+
+on:
+  issues:
+    types:
+      - opened
+
+permissions:
+  issues: write
+
+jobs:
+  add-needs-triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add needs-triage label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: gh issue edit "$ISSUE_NUMBER" --add-label "needs-triage"


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically applies the `needs-triage` label to every newly opened issue, so untriaged issues are easy to find and filter.

## How it works

- Triggers on `issues: opened` (the `issues` event does **not** fire for pull requests, so PRs are unaffected).
- Runs with the minimal `issues: write` permission using the built-in `GITHUB_TOKEN` — no secrets to configure.
- Applies the label with a single `gh issue edit` call. The issue number is passed via an `env:` var rather than interpolated into the `run:` script (avoids template-injection; zizmor-clean).

The `needs-triage` label itself was created once out-of-band, so the workflow only *applies* it rather than recreating it on every run. If the label is ever deleted, the next run fails loudly (surfacing the misconfiguration) instead of silently masking it.

## Notes

- The repo already uses a `triage:` namespace (`triage:done`). This PR uses `needs-triage` as requested; if you'd prefer namespace consistency, `triage:needs` would pair naturally — happy to rename.

## Test plan

- [ ] Open a throwaway issue and confirm `needs-triage` is applied automatically within a few seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
