### PR TITLE
fix(send): classify tree buffers by filetype only (#289)

### DIFF
--- a/fixtures/issue-289/README.md
+++ b/fixtures/issue-289/README.md
@@ -1,0 +1,87 @@
+# Fixture: issue #289 — path-substring tree misclassification
+
+Reproduces [#289](https://github.com/coder/claudecode.nvim/issues/289):
+
+> `ClaudeCodeSend` misclassifies a regular file buffer as a "tree buffer" when
+> the **file path** (not filetype) contains the substring `neo-tree`,
+> `NvimTree`, or `minifiles://`.
+
+## Root cause
+
+`handle_send_normal` and `handle_send_visual` in `lua/claudecode/init.lua`
+decide whether the current buffer is a file-explorer ("tree") buffer using both
+the filetype **and** a substring match against the buffer **name**:
+
+```lua
+local is_tree_buffer = current_ft == "NvimTree"
+  or current_ft == "neo-tree"
+  or current_ft == "oil"
+  or current_ft == "minifiles"
+  or current_ft == "netrw"
+  or current_ft == "snacks_picker_list"   -- (normal handler only)
+  or string.match(current_bufname, "neo%-tree")    -- ← false positive
+  or string.match(current_bufname, "NvimTree")     -- ← false positive
+  or string.match(current_bufname, "minifiles://")
+```
+
+A perfectly ordinary `lua` file whose **path** merely contains one of those
+substrings (e.g. a plugin spec named `_neo-tree_.lua`, or anything under a
+`nvim-tree-config/` directory) is therefore treated as a tree buffer.
+
+## Files
+
+| File                         | Path contains | Classified as tree? |
+| ---------------------------- | ------------- | ------------------- |
+| `lua/plugins/_neo-tree_.lua` | `neo-tree`    | **yes (bug)**       |
+| `lua/NvimTree_settings.lua`  | `NvimTree`    | **yes (bug)**       |
+| `lua/regular_plugin.lua`     | _(none)_      | no (control)        |
+
+All three are plain `filetype=lua` files. Only the path differs.
+
+## Reproduce manually
+
+```bash
+source fixtures/nvim-aliases.sh
+vv issue-289 'lua/plugins/_neo-tree_.lua'   # AFFECTED
+# (or) vv issue-289 'lua/regular_plugin.lua' # CONTROL
+```
+
+or directly:
+
+```bash
+NVIM_APPNAME=issue-289 XDG_CONFIG_HOME=fixtures \
+  nvim fixtures/issue-289/lua/plugins/_neo-tree_.lua
+```
+
+Then, in the buffer:
+
+1. **Visual path** (the README-default `<leader>as`, which maps to
+   `<cmd>ClaudeCodeSend<cr>` and keeps visual mode): visually select a few lines
+   (`Vjj`) and press `<leader>as`.
+   → `ClaudeCode Error [ClaudeCode] [command] [ERROR] ClaudeCodeSend_visual->TreeAdd: Not in visual mode (current mode: n)`
+2. **Range path**: visually select a few lines, then `:'<,'>ClaudeCodeSend`.
+   → `ClaudeCode Error [ClaudeCode] [command] [ERROR] ClaudeCodeSend->TreeAdd: Not in a supported tree buffer (current filetype: lua)`
+
+Doing the same in `regular_plugin.lua` sends the selection with no error.
+
+## Helper commands (provided by this fixture's `init.lua`)
+
+- `:ReproState [path]` — write the current buffer's tree-classification state
+  (`filetype`, `bufname`, `matches_filetype`, `matches_bufname`,
+  `is_tree_buffer`, …) as JSON. On the affected files you will see
+  `matches_filetype=false` but `is_tree_buffer=true`.
+- `:ReproDump [path]` — write all captured ClaudeCode notifications as JSON.
+- `:ReproClear` — clear the captured-notification buffer.
+
+## Headless / automated reproduction
+
+For a deterministic, CI-style check that drives the real `:ClaudeCodeSend`
+command and exits non-zero when the bug is present:
+
+```bash
+nvim --headless -u NONE -l scripts/repro_issue_289.lua; echo "exit=$?"
+```
+
+`exit=1` ⇒ reproduced (a `lua` buffer whose path contains `neo-tree` is
+misrouted into tree extraction while the control buffer sends correctly).
+`exit=0` ⇒ fixed.

--- a/fixtures/issue-289/README.md
+++ b/fixtures/issue-289/README.md
@@ -67,9 +67,12 @@ Doing the same in `regular_plugin.lua` sends the selection with no error.
 ## Helper commands (provided by this fixture's `init.lua`)
 
 - `:ReproState [path]` — write the current buffer's tree-classification state
-  (`filetype`, `bufname`, `matches_filetype`, `matches_bufname`,
-  `is_tree_buffer`, …) as JSON. On the affected files you will see
-  `matches_filetype=false` but `is_tree_buffer=true`.
+  (`filetype`, `bufname`, `matches_filetype`, `legacy_path_substring_match`,
+  `is_tree_buffer`, …) as JSON. `is_tree_buffer` mirrors the plugin's current
+  (filetype-only) predicate. On the affected files you will see
+  `legacy_path_substring_match=true` (the pre-#289 root cause) while
+  `matches_filetype=false`; on **unfixed** code `is_tree_buffer` is `true`
+  (the bug), and on **fixed** code it is `false` (correctly a normal buffer).
 - `:ReproDump [path]` — write all captured ClaudeCode notifications as JSON.
 - `:ReproClear` — clear the captured-notification buffer.
 

--- a/fixtures/issue-289/init.lua
+++ b/fixtures/issue-289/init.lua
@@ -1,0 +1,140 @@
+-- Repro fixture for issue #289:
+--   "[BUG] ClaudeCodeSend misclassifies regular buffers as tree buffers when
+--    file path contains 'neo-tree' or 'NvimTree'"
+--
+-- Root cause (lua/claudecode/init.lua, handle_send_normal + handle_send_visual):
+-- a buffer is classified as a file-explorer ("tree") buffer not only by its
+-- FILETYPE but also by a substring match against its BUFFER NAME:
+--
+--     local is_tree_buffer = current_ft == "NvimTree"
+--       or current_ft == "neo-tree"
+--       or ...
+--       or string.match(current_bufname, "neo%-tree")    -- false positive
+--       or string.match(current_bufname, "NvimTree")     -- false positive
+--       or string.match(current_bufname, "minifiles://")
+--
+-- So a perfectly ordinary file whose PATH happens to contain one of those
+-- substrings (e.g. a Neovim plugin spec at lua/plugins/_neo-tree_.lua, or any
+-- file under a directory called nvim-tree-config/) is mistaken for a tree.
+--
+-- Symptom, visual path (the README-default `<leader>as` keymap uses
+-- `<cmd>ClaudeCodeSend<cr>`, which KEEPS the buffer in visual mode):
+--   1. wrapper sees mode == "v" -> exit_visual_and_schedule(visual_handler)
+--   2. capture_visual_selection_data() returns nil (get_tree_state() is nil for
+--      a real `lua` buffer) and <Esc> is fed, dropping us into normal mode
+--   3. handle_send_visual: is_tree_buffer == true (bufname match) -> takes the
+--      tree branch -> get_files_from_visual_selection(nil) -> validate_visual_mode()
+--      now fails because the mode is "n" -> logs:
+--        ClaudeCodeSend_visual->TreeAdd: Not in visual mode (current mode: n)
+--   ...and nothing is ever sent to Claude.
+--
+-- Symptom, normal/range path (`:'<,'>ClaudeCodeSend`): mode is "n", so
+-- handle_send_normal runs; is_tree_buffer is still true, so it calls
+-- integrations.get_selected_files_from_tree(), which fails with:
+--   ClaudeCodeSend->TreeAdd: Not in a supported tree buffer (current filetype: lua)
+--
+-- A control file whose path has NONE of those substrings works correctly.
+--
+-- Usage (from repo root):
+--   source fixtures/nvim-aliases.sh
+--   vv issue-289 'lua/plugins/_neo-tree_.lua'   # AFFECTED (path has 'neo-tree')
+--   vv issue-289 'lua/regular_plugin.lua'       # CONTROL (no substring)
+-- or directly:
+--   NVIM_APPNAME=issue-289 XDG_CONFIG_HOME=fixtures \
+--     nvim fixtures/issue-289/lua/plugins/_neo-tree_.lua
+--
+-- Commands provided for automation:
+--   :ReproDump [path]   write captured ClaudeCode notifications as JSON to `path`
+--                       (defaults to stdpath('cache')/issue289_notifications.json)
+--   :ReproClear         clear the captured-notification buffer
+
+local config_dir = vim.fn.stdpath("config")
+local repo_root = vim.fn.fnamemodify(config_dir, ":h:h")
+vim.opt.rtp:prepend(repo_root)
+
+vim.g.mapleader = " "
+vim.g.maplocalleader = "\\"
+
+-- A little extra command height keeps long error notifications from triggering
+-- the blocking hit-enter prompt while driving Neovim with agent-tty.
+vim.o.cmdheight = 3
+vim.o.more = false
+
+-- Capture every ClaudeCode notification so automation can assert on it without
+-- scraping the screen. We still forward to the original handler so the error is
+-- also visible in a screenshot.
+_G._repro_notifications = {}
+local original_notify = vim.notify
+vim.notify = function(msg, level, opts)
+  table.insert(_G._repro_notifications, {
+    message = tostring(msg),
+    level = level,
+    title = opts and opts.title or nil,
+  })
+  return original_notify(msg, level, opts)
+end
+
+local ok, claudecode = pcall(require, "claudecode")
+assert(ok, "Failed to load claudecode.nvim from repo root: " .. tostring(claudecode))
+
+claudecode.setup({
+  auto_start = false,
+  -- ERROR notifications fire regardless of log_level; "info" keeps the rest quiet.
+  log_level = "info",
+  -- No in-editor terminal needed to reproduce the misclassification.
+  terminal = {
+    provider = "none",
+  },
+})
+
+-- Best-effort: start the server so the CONTROL path can actually queue an
+-- at-mention. The bug itself does NOT require a running server or a connected
+-- client -- the misclassification happens before any server interaction.
+pcall(function()
+  claudecode.start(false)
+end)
+
+-- README-default visual keymap: this is the exact mapping the docs recommend
+-- and the one the reporter uses. `<cmd>...<cr>` PRESERVES visual mode, which is
+-- what routes the request into the (buggy) visual tree-extraction path.
+vim.keymap.set("v", "<leader>as", "<cmd>ClaudeCodeSend<cr>", { desc = "Send to Claude" })
+
+vim.api.nvim_create_user_command("ReproDump", function(opts)
+  local path = opts.args ~= "" and opts.args or (vim.fn.stdpath("cache") .. "/issue289_notifications.json")
+  vim.fn.writefile({ vim.json.encode(_G._repro_notifications) }, path)
+  original_notify("ReproDump -> " .. path .. " (" .. #_G._repro_notifications .. " notifications)", vim.log.levels.INFO)
+end, { nargs = "?", desc = "Write captured ClaudeCode notifications as JSON" })
+
+vim.api.nvim_create_user_command("ReproClear", function()
+  _G._repro_notifications = {}
+end, { desc = "Clear captured ClaudeCode notifications" })
+
+-- Diagnostic snapshot: records how the CURRENT buffer would be classified so
+-- automation can assert on the misclassification directly (no screen-scraping).
+vim.api.nvim_create_user_command("ReproState", function(opts)
+  local path = opts.args ~= "" and opts.args or (vim.fn.stdpath("cache") .. "/issue289_state.json")
+  local buf = 0
+  local ft = vim.bo[buf].filetype
+  local bufname = vim.api.nvim_buf_get_name(buf)
+  -- Mirror the exact classification predicate from init.lua handle_send_*.
+  local matches_filetype = ft == "NvimTree" or ft == "neo-tree" or ft == "oil" or ft == "minifiles" or ft == "netrw"
+  local matches_bufname = (string.match(bufname, "neo%-tree") ~= nil)
+    or (string.match(bufname, "NvimTree") ~= nil)
+    or (string.match(bufname, "minifiles://") ~= nil)
+  local state = {
+    filetype = ft,
+    bufname = bufname,
+    matches_filetype = matches_filetype,
+    matches_bufname = matches_bufname,
+    -- The plugin's effective decision is the OR of the two; the bug is that
+    -- matches_bufname alone (with a non-tree filetype) flips this to true.
+    is_tree_buffer = matches_filetype or matches_bufname,
+    has_send_command = vim.fn.exists(":ClaudeCodeSend") == 2,
+    server_running = (function()
+      local ok_cc, cc = pcall(require, "claudecode")
+      return ok_cc and cc.state and cc.state.server ~= nil or false
+    end)(),
+  }
+  vim.fn.writefile({ vim.json.encode(state) }, path)
+  original_notify("ReproState -> " .. path, vim.log.levels.INFO)
+end, { nargs = "?", desc = "Write current-buffer tree-classification state as JSON" })

--- a/fixtures/issue-289/init.lua
+++ b/fixtures/issue-289/init.lua
@@ -116,19 +116,24 @@ vim.api.nvim_create_user_command("ReproState", function(opts)
   local buf = 0
   local ft = vim.bo[buf].filetype
   local bufname = vim.api.nvim_buf_get_name(buf)
-  -- Mirror the exact classification predicate from init.lua handle_send_*.
+  -- `is_tree_buffer` mirrors the plugin's CURRENT predicate (post-#289):
+  -- filetype only. On the fixed plugin, running this in `_neo-tree_.lua` reports
+  -- is_tree_buffer=false, i.e. the file is correctly treated as a normal buffer.
   local matches_filetype = ft == "NvimTree" or ft == "neo-tree" or ft == "oil" or ft == "minifiles" or ft == "netrw"
-  local matches_bufname = (string.match(bufname, "neo%-tree") ~= nil)
+  -- Legacy pre-#289 signal: the buffer-NAME substring match that USED to also
+  -- flip is_tree_buffer to true (the root cause of #289). Reported for
+  -- diagnostics so the fixture still shows why ordinary files misfired before
+  -- the fix: legacy_path_substring_match=true while is_tree_buffer=false means
+  -- "this file would have been misclassified by the old code".
+  local legacy_path_substring_match = (string.match(bufname, "neo%-tree") ~= nil)
     or (string.match(bufname, "NvimTree") ~= nil)
     or (string.match(bufname, "minifiles://") ~= nil)
   local state = {
     filetype = ft,
     bufname = bufname,
     matches_filetype = matches_filetype,
-    matches_bufname = matches_bufname,
-    -- The plugin's effective decision is the OR of the two; the bug is that
-    -- matches_bufname alone (with a non-tree filetype) flips this to true.
-    is_tree_buffer = matches_filetype or matches_bufname,
+    legacy_path_substring_match = legacy_path_substring_match,
+    is_tree_buffer = matches_filetype,
     has_send_command = vim.fn.exists(":ClaudeCodeSend") == 2,
     server_running = (function()
       local ok_cc, cc = pcall(require, "claudecode")

--- a/fixtures/issue-289/lua/NvimTree_settings.lua
+++ b/fixtures/issue-289/lua/NvimTree_settings.lua
@@ -1,0 +1,16 @@
+-- AFFECTED FILE (NvimTree variant) for issue #289.
+--
+-- Same bug as `_neo-tree_.lua`, but triggered by the
+-- `string.match(current_bufname, "NvimTree")` substring check. Filetype is
+-- still `lua`; only the path contains "NvimTree".
+
+local M = {}
+
+M.opts = {
+  sort = { sorter = "case_sensitive" },
+  view = { width = 30 },
+  renderer = { group_empty = true },
+  filters = { dotfiles = true },
+}
+
+return M

--- a/fixtures/issue-289/lua/plugins/_neo-tree_.lua
+++ b/fixtures/issue-289/lua/plugins/_neo-tree_.lua
@@ -1,0 +1,27 @@
+-- AFFECTED FILE for issue #289.
+--
+-- This is an utterly ordinary Lua file. Its FILETYPE is `lua`. The ONLY reason
+-- ClaudeCodeSend misbehaves here is that its PATH contains the substring
+-- "neo-tree" (this file is named `_neo-tree_.lua`), which trips the
+-- `string.match(current_bufname, "neo%-tree")` false positive.
+--
+-- Visually select a few of these lines and press <leader>as (or run
+-- :'<,'>ClaudeCodeSend) -> you get a TreeAdd error and nothing is sent.
+
+return {
+  "nvim-neo-tree/neo-tree.nvim",
+  branch = "v3.x",
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+    "nvim-tree/nvim-web-devicons",
+    "MunifTanjim/nui.nvim",
+  },
+  config = function()
+    require("neo-tree").setup({
+      close_if_last_window = true,
+      filesystem = {
+        follow_current_file = { enabled = true },
+      },
+    })
+  end,
+}

--- a/fixtures/issue-289/lua/regular_plugin.lua
+++ b/fixtures/issue-289/lua/regular_plugin.lua
@@ -1,0 +1,20 @@
+-- CONTROL FILE for issue #289.
+--
+-- Identical in spirit to `_neo-tree_.lua`, but its path contains NONE of the
+-- magic substrings (no "neo-tree", "NvimTree", or "minifiles://"). Visually
+-- selecting lines here and pressing <leader>as works correctly: the selection
+-- is sent (or queued) with no TreeAdd error.
+
+return {
+  "some-author/some-plugin.nvim",
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+  },
+  config = function()
+    require("some-plugin").setup({
+      enabled = true,
+      option_one = "value",
+      option_two = 42,
+    })
+  end,
+}

--- a/lua/claudecode/init.lua
+++ b/lua/claudecode/init.lua
@@ -727,17 +727,19 @@ function M._create_commands()
 
   local function handle_send_normal(opts)
     local current_ft = (vim.bo and vim.bo.filetype) or ""
-    local current_bufname = (vim.api and vim.api.nvim_buf_get_name and vim.api.nvim_buf_get_name(0)) or ""
 
+    -- Classify tree/explorer buffers by FILETYPE only. Matching the buffer name
+    -- (an absolute path) misfires on ordinary files whose path merely contains a
+    -- substring like "neo-tree"/"NvimTree" (issue #289). The downstream
+    -- extractors (integrations.get_selected_files_from_tree /
+    -- visual_commands.get_tree_state) are filetype-only, so a name-only match
+    -- could never extract anyway.
     local is_tree_buffer = current_ft == "NvimTree"
       or current_ft == "neo-tree"
       or current_ft == "oil"
       or current_ft == "minifiles"
       or current_ft == "netrw"
       or current_ft == "snacks_picker_list"
-      or string.match(current_bufname, "neo%-tree")
-      or string.match(current_bufname, "NvimTree")
-      or string.match(current_bufname, "minifiles://")
 
     if is_tree_buffer then
       local integrations = require("claudecode.integrations")
@@ -781,18 +783,16 @@ function M._create_commands()
   end
 
   local function handle_send_visual(visual_data, opts)
-    -- Check if we're in a tree buffer first
+    -- Check if we're in a tree buffer first. Classify by FILETYPE only; matching
+    -- the buffer name (an absolute path) misfires on ordinary files whose path
+    -- merely contains "neo-tree"/"NvimTree" (issue #289).
     local current_ft = (vim.bo and vim.bo.filetype) or ""
-    local current_bufname = (vim.api and vim.api.nvim_buf_get_name and vim.api.nvim_buf_get_name(0)) or ""
 
     local is_tree_buffer = current_ft == "NvimTree"
       or current_ft == "neo-tree"
       or current_ft == "oil"
       or current_ft == "minifiles"
       or current_ft == "netrw"
-      or string.match(current_bufname, "neo%-tree")
-      or string.match(current_bufname, "NvimTree")
-      or string.match(current_bufname, "minifiles://")
 
     if is_tree_buffer then
       local integrations = require("claudecode.integrations")
@@ -800,7 +800,7 @@ function M._create_commands()
       local files, error
 
       -- For mini.files, try to get the range from visual marks for accuracy
-      if current_ft == "minifiles" or string.match(current_bufname, "minifiles://") then
+      if current_ft == "minifiles" then
         local start_line = vim.fn.line("'<")
         local end_line = vim.fn.line("'>")
 

--- a/scripts/repro_issue_289.lua
+++ b/scripts/repro_issue_289.lua
@@ -1,0 +1,205 @@
+-- Reproduction / verification for issue #289:
+--   "[BUG] ClaudeCodeSend misclassifies regular buffers as tree buffers when
+--    file path contains 'neo-tree' or 'NvimTree'"
+--   https://github.com/coder/claudecode.nvim/issues/289
+--
+-- The bug: handle_send_normal and handle_send_visual (lua/claudecode/init.lua)
+-- decide whether the current buffer is a file-explorer ("tree") buffer using
+-- BOTH the filetype AND a substring match against the buffer NAME:
+--
+--     local is_tree_buffer = current_ft == "NvimTree"
+--       or current_ft == "neo-tree" or current_ft == "oil"
+--       or current_ft == "minifiles" or current_ft == "netrw"
+--       or string.match(current_bufname, "neo%-tree")    -- false positive
+--       or string.match(current_bufname, "NvimTree")     -- false positive
+--       or string.match(current_bufname, "minifiles://")
+--
+-- So an ordinary `lua` file whose PATH merely contains "neo-tree" / "NvimTree"
+-- (e.g. a plugin spec named `_neo-tree_.lua`) is treated as a tree buffer, and
+-- a visual send is routed into tree-extraction instead of the normal selection
+-- path. Result, depending on how the command is invoked:
+--   * `:'<,'>ClaudeCodeSend`        -> ClaudeCodeSend->TreeAdd: Not in a
+--                                       supported tree buffer (current filetype: lua)
+--   * <leader>as (`<cmd>...<cr>`)   -> ClaudeCodeSend_visual->TreeAdd: Not in
+--                                       visual mode (current mode: n)
+-- ...and nothing is sent to Claude.
+--
+-- This script drives the REAL `:ClaudeCodeSend` user command (registered by
+-- claudecode.setup) against both an affected buffer and a control buffer, with
+-- no WebSocket / Claude CLI needed. It reproduces the bug on unfixed code and
+-- will verify a fix.
+--
+-- Run from the repo root:
+--   nvim --headless -u NONE -l scripts/repro_issue_289.lua
+--
+-- Exit code: 1 if the misclassification is observed (#289 reproduced), 0 if the
+-- affected buffer behaves like the control (fixed). A detailed verdict is
+-- printed either way.
+
+vim.g.mapleader = " " -- must be set before the <leader> mapping is created
+vim.g.maplocalleader = "\\"
+
+local script_path = debug.getinfo(1, "S").source:sub(2)
+local repo_root = vim.fn.fnamemodify(script_path, ":h:h")
+vim.opt.rtp:prepend(repo_root)
+
+local function out(msg)
+  io.stdout:write(msg .. "\n")
+end
+
+-- Capture (and swallow) ClaudeCode notifications so we can assert on the error
+-- text without it cluttering the output.
+local captured = {}
+vim.notify = function(msg, level, opts)
+  table.insert(captured, { message = tostring(msg), level = level, title = opts and opts.title or nil })
+end
+-- The logger wraps notify in vim.schedule; nvim_echo is used for lower levels.
+local orig_echo = vim.api.nvim_echo
+vim.api.nvim_echo = function() end
+
+local cc = require("claudecode")
+cc.setup({
+  auto_start = false,
+  log_level = "info",
+  terminal = { provider = "none" },
+})
+-- A server object only matters for the *downstream* send; the misclassification
+-- happens before that. Provide a stub so the "correct" path can complete.
+cc.state.server = cc.state.server or {
+  broadcast = function()
+    return true
+  end,
+}
+
+-- Spy on the two mutually-exclusive downstream paths.
+local selection = require("claudecode.selection")
+local sent = { count = 0, args = nil }
+selection.send_at_mention_for_visual_selection = function(l1, l2)
+  sent.count = sent.count + 1
+  sent.args = { l1, l2 }
+  return true
+end
+
+local integrations = require("claudecode.integrations")
+local tree = { count = 0 }
+integrations.get_selected_files_from_tree = function()
+  tree.count = tree.count + 1
+  -- Mirror the real error text for a non-tree filetype.
+  return {}, "Not in a supported tree buffer (current filetype: lua)"
+end
+
+-- README-default visual mapping (the reporter's mapping). `<cmd>...<cr>` keeps
+-- visual mode, which routes into handle_send_visual.
+vim.keymap.set("v", "<leader>as", "<cmd>ClaudeCodeSend<cr>")
+
+local LUA_LINES = {
+  "return {",
+  '  "nvim-neo-tree/neo-tree.nvim",',
+  "  branch = 'v3.x',",
+  "  config = function() end,",
+  "}",
+}
+
+local function open_buffer(path)
+  vim.cmd("enew!")
+  local buf = vim.api.nvim_get_current_buf()
+  vim.api.nvim_buf_set_name(buf, path)
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, LUA_LINES)
+  vim.bo[buf].filetype = "lua"
+  vim.api.nvim_win_set_cursor(0, { 1, 0 })
+  return buf
+end
+
+local function first_treeadd_error()
+  for _, n in ipairs(captured) do
+    if n.message:match("TreeAdd") then
+      return n.message
+    end
+  end
+  return nil
+end
+
+-- Exercise both invocation styles against one buffer.
+---@return table result {range_sent, range_tree, range_err, visual_err}
+local function exercise(path)
+  open_buffer(path)
+
+  -- (1) Range path: `:1,3ClaudeCodeSend` (mode is normal -> handle_send_normal)
+  captured, sent.count, tree.count = {}, 0, 0
+  pcall(function()
+    vim.cmd("1,3ClaudeCodeSend")
+  end)
+  vim.wait(60)
+  local range_sent = sent.count
+  local range_tree = tree.count
+  local range_err = first_treeadd_error()
+
+  -- (2) Visual path: real visual selection + <leader>as (-> handle_send_visual)
+  captured, sent.count, tree.count = {}, 0, 0
+  vim.api.nvim_win_set_cursor(0, { 1, 0 })
+  local keys = vim.api.nvim_replace_termcodes("Vjj as", true, false, true)
+  pcall(function()
+    vim.api.nvim_feedkeys(keys, "x", false)
+  end)
+  vim.wait(120)
+  local visual_err = first_treeadd_error()
+  local visual_sent = sent.count
+
+  return {
+    range_sent = range_sent,
+    range_tree = range_tree,
+    range_err = range_err,
+    visual_err = visual_err,
+    visual_sent = visual_sent,
+  }
+end
+
+out("== issue #289 reproduction (path-substring tree misclassification) ==")
+out(("Neovim: %s"):format(tostring(vim.version())))
+
+local AFFECTED = vim.fn.tempname() .. "/lua/plugins/_neo-tree_.lua"
+local CONTROL = vim.fn.tempname() .. "/lua/plugins/regular_plugin.lua"
+
+local affected = exercise(AFFECTED)
+local control = exercise(CONTROL)
+
+local function report(label, path, r)
+  out(("\n[%s]  %s"):format(label, path))
+  out(
+    ("  range  : sent=%d tree_extract=%d  %s"):format(
+      r.range_sent,
+      r.range_tree,
+      r.range_err and ("ERROR: " .. r.range_err:gsub("%s+", " ")) or "(no TreeAdd error)"
+    )
+  )
+  out(
+    ("  visual : sent=%d  %s"):format(
+      r.visual_sent,
+      r.visual_err and ("ERROR: " .. r.visual_err:gsub("%s+", " ")) or "(no TreeAdd error)"
+    )
+  )
+end
+
+report("AFFECTED", AFFECTED, affected)
+report("CONTROL ", CONTROL, control)
+
+-- Verdict.
+-- Bug present iff the AFFECTED buffer is misrouted into tree extraction on the
+-- (deterministic) range path while the CONTROL buffer is sent correctly.
+local affected_misrouted = (affected.range_sent == 0 and affected.range_tree > 0)
+local affected_visual_err = (affected.visual_err ~= nil)
+local control_ok = (control.range_sent == 1 and control.range_tree == 0 and control.range_err == nil)
+
+out("\n== verdict ==")
+out(("  control behaves correctly      : %s"):format(tostring(control_ok)))
+out(("  affected misrouted (range)     : %s"):format(tostring(affected_misrouted)))
+out(("  affected errored (visual path) : %s"):format(tostring(affected_visual_err)))
+
+if affected_misrouted and control_ok then
+  out("\nRESULT: #289 REPRODUCED -- a `lua` buffer whose path contains 'neo-tree'")
+  out("        is misclassified as a tree buffer and the send fails.")
+  vim.cmd("cquit 1")
+else
+  out("\nRESULT: not reproduced -- affected buffer behaves like the control (fixed).")
+  vim.cmd("cquit 0")
+end

--- a/tests/unit/tree_buffer_classification_spec.lua
+++ b/tests/unit/tree_buffer_classification_spec.lua
@@ -1,0 +1,243 @@
+-- Regression tests for issue #289:
+--   ClaudeCodeSend must classify tree/explorer buffers by FILETYPE only, not by
+--   a substring match on the buffer name (an absolute path). A normal
+--   filetype=lua file whose path contains "neo-tree"/"NvimTree" must NOT be
+--   treated as a tree buffer.
+--
+-- Unlike tree_send_visual_spec.lua (which mocks the visual_commands wrapper),
+-- these tests drive the REAL create_visual_command_wrapper + the REAL
+-- is_tree_buffer predicate, so they actually exercise the classification logic.
+
+require("tests.busted_setup")
+require("tests.mocks.vim")
+
+describe("ClaudeCodeSend tree-buffer classification (#289)", function()
+  local claudecode
+  local command_callback
+  local original_require
+
+  local mock_selection
+  local mock_integrations
+
+  -- Buffer/editor state the predicate and wrapper read; mutated per test.
+  local cur = { ft = "lua", bufname = "/home/user/cfg/lua/plugins/_neo-tree_.lua", mode = "n" }
+
+  before_each(function()
+    package.loaded["claudecode"] = nil
+    package.loaded["claudecode.selection"] = nil
+    package.loaded["claudecode.integrations"] = nil
+    package.loaded["claudecode.terminal"] = nil
+    package.loaded["claudecode.server.init"] = nil
+    package.loaded["claudecode.lockfile"] = nil
+    package.loaded["claudecode.config"] = nil
+    package.loaded["claudecode.logger"] = nil
+    package.loaded["claudecode.diff"] = nil
+    -- visual_commands is intentionally NOT mocked: we use the real wrapper.
+    package.loaded["claudecode.visual_commands"] = nil
+
+    cur = { ft = "lua", bufname = "/home/user/cfg/lua/plugins/_neo-tree_.lua", mode = "n" }
+
+    _G.vim = {
+      api = {
+        nvim_create_user_command = function(name, callback)
+          if name == "ClaudeCodeSend" then
+            command_callback = callback
+          end
+        end,
+        nvim_create_augroup = function()
+          return 1
+        end,
+        nvim_create_autocmd = function()
+          return 1
+        end,
+        nvim_get_mode = function()
+          return { mode = cur.mode }
+        end,
+        nvim_buf_get_name = function()
+          return cur.bufname
+        end,
+        nvim_feedkeys = function()
+          -- Feeding <Esc> drops us out of visual mode, exactly as the real
+          -- exit_visual_and_schedule path does before the scheduled handler runs.
+          cur.mode = "n"
+        end,
+        nvim_replace_termcodes = function(s)
+          return s
+        end,
+        nvim_win_get_cursor = function()
+          return { 1, 0 }
+        end,
+      },
+      bo = setmetatable({}, {
+        __index = function(_, k)
+          if k == "filetype" then
+            return cur.ft
+          end
+        end,
+      }),
+      fn = {
+        mode = function()
+          return cur.mode
+        end,
+        getpos = function()
+          return { 0, 1, 0, 0 }
+        end,
+        line = function(mark)
+          return mark == "'<" and 1 or 3
+        end,
+      },
+      schedule = function(fn)
+        fn()
+      end,
+      notify = function() end,
+      log = { levels = { ERROR = 1, WARN = 2, INFO = 3, DEBUG = 4, TRACE = 5 } },
+      deepcopy = function(t)
+        return t
+      end,
+      tbl_deep_extend = function(_, ...)
+        local result = {}
+        for _, tbl in ipairs({ ... }) do
+          for k, v in pairs(tbl) do
+            result[k] = v
+          end
+        end
+        return result
+      end,
+    }
+
+    mock_selection = {
+      send_at_mention_for_visual_selection = spy.new(function(l1, l2)
+        mock_selection.last = { l1, l2 }
+        return true
+      end),
+    }
+
+    mock_integrations = {
+      get_selected_files_from_tree = spy.new(function()
+        return { "/proj/from_tree.lua" }, nil
+      end),
+      _get_mini_files_selection_with_range = function()
+        return {}, "unused"
+      end,
+    }
+
+    local mock_logger = {
+      setup = function() end,
+      debug = function() end,
+      warn = function() end,
+      error = spy.new(function() end),
+    }
+    mock_selection._logger = mock_logger
+
+    original_require = _G.require
+    _G.require = function(module)
+      if module == "claudecode.selection" then
+        return mock_selection
+      elseif module == "claudecode.integrations" then
+        return mock_integrations
+      elseif module == "claudecode.logger" then
+        return mock_logger
+      elseif module == "claudecode.terminal" then
+        return { setup = function() end, open = function() end, ensure_visible = function() end }
+      elseif module == "claudecode.server.init" then
+        return {
+          get_status = function()
+            return { running = true, client_count = 1 }
+          end,
+        }
+      elseif module == "claudecode.lockfile" then
+        return {
+          create = function()
+            return true, "/tmp/mock.lock", "auth"
+          end,
+          remove = function()
+            return true
+          end,
+          generate_auth_token = function()
+            return "auth"
+          end,
+        }
+      elseif module == "claudecode.config" then
+        return {
+          apply = function(opts)
+            return opts or { log_level = "info" }
+          end,
+        }
+      elseif module == "claudecode.diff" then
+        return { setup = function() end }
+      else
+        return original_require(module)
+      end
+    end
+
+    claudecode = require("claudecode")
+    claudecode.setup({ auto_start = false })
+    claudecode.state.server = { broadcast = spy.new(function()
+      return true
+    end) }
+    claudecode.state.port = 12345
+    -- Tree path fans out via M.send_at_mention; stub it so we can detect routing.
+    claudecode.send_at_mention = spy.new(function()
+      return true
+    end)
+  end)
+
+  after_each(function()
+    _G.require = original_require
+  end)
+
+  it("registers the ClaudeCodeSend command", function()
+    assert.is_function(command_callback)
+  end)
+
+  it("does NOT treat a lua file whose path contains 'neo-tree' as a tree buffer (range path)", function()
+    cur.ft = "lua"
+    cur.mode = "n"
+    cur.bufname = "/home/user/cfg/lua/plugins/_neo-tree_.lua"
+
+    command_callback({ range = 2, line1 = 1, line2 = 3 })
+
+    -- Correct routing: the normal selection path, NOT tree extraction.
+    assert.spy(mock_selection.send_at_mention_for_visual_selection).was_called()
+    assert.same({ 1, 3 }, mock_selection.last)
+    assert.spy(mock_integrations.get_selected_files_from_tree).was_not_called()
+  end)
+
+  it("does NOT treat a lua file whose path contains 'NvimTree' as a tree buffer (range path)", function()
+    cur.ft = "lua"
+    cur.mode = "n"
+    cur.bufname = "/home/user/cfg/lua/NvimTree_settings.lua"
+
+    command_callback({ range = 2, line1 = 4, line2 = 6 })
+
+    assert.spy(mock_selection.send_at_mention_for_visual_selection).was_called()
+    assert.same({ 4, 6 }, mock_selection.last)
+    assert.spy(mock_integrations.get_selected_files_from_tree).was_not_called()
+  end)
+
+  it("does NOT misroute a 'neo-tree'-named lua file on the visual path", function()
+    cur.ft = "lua"
+    cur.mode = "v" -- real visual mode -> wrapper takes exit_visual_and_schedule
+    cur.bufname = "/home/user/cfg/lua/plugins/_neo-tree_.lua"
+
+    command_callback({})
+
+    -- After <Esc> drops us to normal mode, the fixed predicate is filetype-only,
+    -- so the buffer is treated as plain text and the selection is sent -- no
+    -- "ClaudeCodeSend_visual->TreeAdd" error, no tree extraction.
+    assert.spy(mock_selection.send_at_mention_for_visual_selection).was_called()
+    assert.spy(mock_integrations.get_selected_files_from_tree).was_not_called()
+  end)
+
+  it("STILL treats a real tree filetype (neo-tree) as a tree buffer (no over-correction)", function()
+    cur.ft = "neo-tree"
+    cur.mode = "n"
+    cur.bufname = "neo-tree filesystem [1]"
+
+    command_callback({ range = 0 })
+
+    -- Real explorer buffers must keep routing into tree extraction.
+    assert.spy(mock_integrations.get_selected_files_from_tree).was_called()
+    assert.spy(mock_selection.send_at_mention_for_visual_selection).was_not_called()
+  end)
+end)


### PR DESCRIPTION
## Summary

Fixes #289.

`ClaudeCodeSend` classified the current buffer as a file-explorer ("tree") buffer using a substring match against the **buffer name** (the file's absolute path) in addition to the filetype, in both `handle_send_normal` and `handle_send_visual`:

```lua
or string.match(current_bufname, "neo%-tree")
or string.match(current_bufname, "NvimTree")
or string.match(current_bufname, "minifiles://")
```

So an ordinary `filetype=lua` file whose path merely contained `neo-tree` or `NvimTree` (e.g. a plugin spec named `_neo-tree_.lua`) was treated as a tree buffer and the send was misrouted into tree-extraction, failing with:

- visual path (`<leader>as` → `<cmd>ClaudeCodeSend<cr>`): `ClaudeCodeSend_visual->TreeAdd: Not in visual mode (current mode: n)`
- range path (`:'<,'>ClaudeCodeSend`): `ClaudeCodeSend->TreeAdd: Not in a supported tree buffer (current filetype: lua)`

## Why this is the right fix

The two downstream extractors — `integrations.get_selected_files_from_tree()` and `visual_commands.get_tree_state()` — already classify by **filetype only**. A buffer matched as a tree purely via its name therefore could never extract anything; the substring checks only ever diverted a normal selection into a failing branch.

Every supported explorer sets a distinctive filetype that those extractors key on (`neo-tree`, `NvimTree`, `oil`, `minifiles`, `netrw`), so removing the name checks does not regress any of them. In particular, mini.files sets `filetype=minifiles` in addition to its `minifiles://` buffer name, so the `minifiles://` branch is redundant (and was never a cause of this bug — a real path cannot contain `://`).

## Changes

- `lua/claudecode/init.lua`: classify by filetype only in both `handle_send_normal` and `handle_send_visual`; drop the now-unused `current_bufname` locals and the redundant `minifiles://` discriminator.
- `tests/unit/tree_buffer_classification_spec.lua`: new regression spec that drives the **real** predicate (the existing `tree_send_visual_spec` mocks the wrapper, so the predicate was untested). Verified two-sided: fails on the old code, passes on the fix.
- `scripts/repro_issue_289.lua`: headless reproduction (exit 1 = bug present, 0 = fixed).
- `fixtures/issue-289/`: interactive reproduction fixture (affected + control files, `:ReproState`/`:ReproDump` helpers).

## Verification

- `mise run all` — format + lint + 663 tests pass.
- `nvim --headless -u NONE -l scripts/repro_issue_289.lua` — exits 0 on this branch (1 on `main`).
- Reproduced live with the README-default `<leader>as` mapping before/after the fix.

## Follow-ups (out of scope, noted for tracking)

- `snacks_picker_list` is present in `handle_send_normal` but missing from `handle_send_visual`, and there is no snacks branch in `get_tree_state`/`get_files_from_visual_selection` — visual-mode snacks-picker send is currently unsupported (needs end-to-end work).
- Tree-buffer classification is duplicated across four sites; a shared helper would prevent future drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
