### PR TITLE
fix(diff): emit lifecycle events for unified layout

### DIFF
--- a/lua/claudecode/diff.lua
+++ b/lua/claudecode/diff.lua
@@ -1171,6 +1171,11 @@ function M._cleanup_diff_state(tab_name, reason)
     local inline = require("claudecode.diff_inline")
     inline.cleanup_inline_diff(tab_name, diff_data)
     active_diffs[tab_name] = nil
+    fire_diff_event("ClaudeCodeDiffClosed", {
+      tab_name = tab_name,
+      file_path = diff_data.old_file_path,
+      reason = reason,
+    })
     return
   end
 
@@ -1319,6 +1324,20 @@ function M._setup_blocking_diff(params, resolution_callback)
     if config and config.diff_opts and config.diff_opts.layout == "unified" then
       local inline = require("claudecode.diff_inline")
       inline.setup_inline_diff(params, resolution_callback, config)
+
+      local state = active_diffs[tab_name]
+      if state then
+        fire_diff_event("ClaudeCodeDiffOpened", {
+          tab_name = tab_name,
+          file_path = params.old_file_path,
+          new_file_path = params.new_file_path,
+          is_new_file = state.is_new_file,
+          diff_window = state.new_window,
+          target_window = state.target_window,
+          terminal_window = state.terminal_win_in_new_tab or find_claudecode_terminal_window(),
+          tab_number = state.created_new_tab and state.new_tab_number or nil,
+        })
+      end
       return
     end
 

--- a/lua/claudecode/diff_inline.lua
+++ b/lua/claudecode/diff_inline.lua
@@ -142,6 +142,84 @@ function M.render_diff_buffer(buf, lines, line_types)
   end
 end
 
+--- Create a scratch editor window when the current tab only has terminal/sidebar windows.
+---@return number win_id Window ID of the created scratch editor window
+local function create_fallback_editor_window()
+  vim.cmd("rightbelow vsplit")
+  local fallback_win = vim.api.nvim_get_current_win()
+
+  local ok, err = pcall(function()
+    local scratch_buf = vim.api.nvim_create_buf(false, true)
+    if scratch_buf == 0 then
+      error({ code = -32000, message = "Buffer creation failed", data = "Could not create fallback editor buffer" })
+    end
+
+    vim.api.nvim_buf_set_option(scratch_buf, "bufhidden", "wipe")
+    vim.api.nvim_win_set_buf(fallback_win, scratch_buf)
+  end)
+
+  if not ok then
+    if fallback_win and vim.api.nvim_win_is_valid(fallback_win) then
+      pcall(vim.api.nvim_win_close, fallback_win, true)
+    end
+    error(err)
+  end
+
+  return fallback_win
+end
+
+--- Clean up inline diff resources if setup fails before state registration.
+---@param tab_name string Diff identifier
+---@param partial table Partially created resources
+local function cleanup_unregistered_inline_setup(tab_name, partial)
+  local diff = require("claudecode.diff")
+
+  if diff._get_active_diffs()[tab_name] then
+    diff._cleanup_diff_state(tab_name, "setup failed")
+    return
+  end
+
+  for _, autocmd_id in ipairs(partial.autocmd_ids or {}) do
+    pcall(vim.api.nvim_del_autocmd, autocmd_id)
+  end
+
+  local original_tab = partial.original_tab_number
+  local stranded_tab = partial.new_tab_number
+  if not (stranded_tab and vim.api.nvim_tabpage_is_valid(stranded_tab)) then
+    local current_tab = vim.api.nvim_get_current_tabpage()
+    if original_tab and vim.api.nvim_tabpage_is_valid(original_tab) and current_tab ~= original_tab then
+      stranded_tab = current_tab
+    end
+  end
+
+  if stranded_tab and vim.api.nvim_tabpage_is_valid(stranded_tab) and stranded_tab ~= original_tab then
+    pcall(vim.api.nvim_set_current_tabpage, stranded_tab)
+    pcall(vim.cmd, "tabclose")
+    if original_tab and vim.api.nvim_tabpage_is_valid(original_tab) then
+      pcall(vim.api.nvim_set_current_tabpage, original_tab)
+    end
+  else
+    if partial.diff_window and vim.api.nvim_win_is_valid(partial.diff_window) then
+      pcall(vim.api.nvim_win_close, partial.diff_window, true)
+    end
+
+    if partial.fallback_window and vim.api.nvim_win_is_valid(partial.fallback_window) then
+      pcall(vim.api.nvim_win_close, partial.fallback_window, true)
+    end
+  end
+
+  if partial.new_buffer and vim.api.nvim_buf_is_valid(partial.new_buffer) then
+    pcall(vim.api.nvim_buf_delete, partial.new_buffer, { force = true })
+  end
+
+  if partial.had_terminal_in_original then
+    local terminal_ok, terminal_module = pcall(require, "claudecode.terminal")
+    if terminal_ok then
+      pcall(terminal_module.ensure_visible)
+    end
+  end
+end
+
 -- ── Setup ─────────────────────────────────────────────────────────
 
 --- Set up an inline diff view for the given parameters.
@@ -222,9 +300,31 @@ function M.setup_inline_diff(params, resolution_callback, config)
   local new_tab_handle = nil
   local had_terminal_in_original = false
 
+  local diff_win
+  local autocmd_ids = {}
+  local partial_setup = {
+    new_buffer = buf,
+    original_tab_number = original_tab_number,
+    autocmd_ids = autocmd_ids,
+  }
+  local function guard_inline_setup(action)
+    local results = { pcall(action) }
+    if not results[1] then
+      cleanup_unregistered_inline_setup(tab_name, partial_setup)
+      error(results[2])
+    end
+    return unpack(results, 2)
+  end
+
   if config and config.diff_opts and config.diff_opts.open_in_new_tab then
-    original_tab_number, terminal_win_in_new_tab, had_terminal_in_original, new_tab_handle =
-      diff._display_terminal_in_new_tab()
+    original_tab_number, terminal_win_in_new_tab, had_terminal_in_original, new_tab_handle = guard_inline_setup(
+      function()
+        return diff._display_terminal_in_new_tab()
+      end
+    )
+    partial_setup.original_tab_number = original_tab_number
+    partial_setup.new_tab_number = new_tab_handle
+    partial_setup.had_terminal_in_original = had_terminal_in_original
     created_new_tab = true
   end
 
@@ -239,6 +339,7 @@ function M.setup_inline_diff(params, resolution_callback, config)
   -- When in a new tab, use a window from the current tab rather than the global
   -- search which could return a window from the original tab
   local editor_win
+  local fallback_window
   if created_new_tab then
     local tab_wins = vim.api.nvim_tabpage_list_wins(0)
     for _, w in ipairs(tab_wins) do
@@ -253,19 +354,28 @@ function M.setup_inline_diff(params, resolution_callback, config)
     end
   else
     editor_win = diff._find_main_editor_window()
+    if not editor_win then
+      fallback_window = guard_inline_setup(create_fallback_editor_window)
+      partial_setup.fallback_window = fallback_window
+      editor_win = fallback_window
+    end
   end
-  if editor_win then
+  guard_inline_setup(function()
+    assert(editor_win and vim.api.nvim_win_is_valid(editor_win), "ClaudeCode unified diff target window must be valid")
     vim.api.nvim_set_current_win(editor_win)
-  end
-  vim.cmd("rightbelow vsplit")
-  local diff_win = vim.api.nvim_get_current_win()
-  vim.api.nvim_win_set_buf(diff_win, buf)
+    vim.cmd("rightbelow vsplit")
+    diff_win = vim.api.nvim_get_current_win()
+    partial_setup.diff_window = diff_win
+    vim.api.nvim_win_set_buf(diff_win, buf)
+  end)
 
   -- Configure window for sign column display
   pcall(vim.api.nvim_set_option_value, "signcolumn", "yes", { win = diff_win })
 
   -- Equalize window widths
-  vim.cmd("wincmd =")
+  guard_inline_setup(function()
+    vim.cmd("wincmd =")
+  end)
 
   -- Scroll to first change
   for i, lt in ipairs(line_types) do
@@ -293,71 +403,75 @@ function M.setup_inline_diff(params, resolution_callback, config)
   end
 
   -- Restore terminal width after opening the split
-  if terminal_win_in_new_tab and vim.api.nvim_win_is_valid(terminal_win_in_new_tab) then
-    local terminal_config = config.terminal or {}
-    local split_width = terminal_config.split_width_percentage or 0.30
-    local total_width = vim.o.columns
-    local terminal_width = math.floor(total_width * split_width)
-    vim.api.nvim_win_set_width(terminal_win_in_new_tab, terminal_width)
-  elseif term_win and vim.api.nvim_win_is_valid(term_win) then
-    local win_config = vim.api.nvim_win_get_config(term_win)
-    local is_floating = win_config.relative and win_config.relative ~= ""
-    if not is_floating and term_width then
-      pcall(vim.api.nvim_win_set_width, term_win, term_width)
+  guard_inline_setup(function()
+    if terminal_win_in_new_tab and vim.api.nvim_win_is_valid(terminal_win_in_new_tab) then
+      local terminal_config = config.terminal or {}
+      local split_width = terminal_config.split_width_percentage or 0.30
+      local total_width = vim.o.columns
+      local terminal_width = math.floor(total_width * split_width)
+      vim.api.nvim_win_set_width(terminal_win_in_new_tab, terminal_width)
+    elseif term_win and vim.api.nvim_win_is_valid(term_win) then
+      local win_config = vim.api.nvim_win_get_config(term_win)
+      local is_floating = win_config.relative and win_config.relative ~= ""
+      if not is_floating and term_width then
+        pcall(vim.api.nvim_win_set_width, term_win, term_width)
+      end
     end
-  end
+  end)
 
-  -- Register autocmds
-  local aug = diff._get_autocmd_group()
-  local autocmd_ids = {}
+  -- Register autocmds and state with layout = "unified"
+  guard_inline_setup(function()
+    local aug = diff._get_autocmd_group()
 
-  autocmd_ids[#autocmd_ids + 1] = vim.api.nvim_create_autocmd("BufWriteCmd", {
-    group = aug,
-    buffer = buf,
-    callback = function()
-      diff._resolve_diff_as_saved(tab_name, buf)
-      return true -- prevent actual write
-    end,
-  })
-
-  for _, ev in ipairs({ "BufDelete", "BufUnload", "BufWipeout" }) do
-    autocmd_ids[#autocmd_ids + 1] = vim.api.nvim_create_autocmd(ev, {
+    autocmd_ids[#autocmd_ids + 1] = vim.api.nvim_create_autocmd("BufWriteCmd", {
       group = aug,
       buffer = buf,
       callback = function()
-        diff._resolve_diff_as_rejected(tab_name)
+        diff._resolve_diff_as_saved(tab_name, buf)
+        return true -- prevent actual write
       end,
     })
-  end
 
-  -- Register state with layout = "unified"
-  diff._register_diff_state(tab_name, {
-    old_file_path = params.old_file_path,
-    new_file_path = params.new_file_path,
-    new_file_contents = params.new_file_contents,
-    new_buffer = buf,
-    new_window = diff_win,
-    lines = lines,
-    line_types = line_types,
-    is_new_file = is_new_file,
-    autocmd_ids = autocmd_ids,
-    created_at = vim.fn.localtime(),
-    status = "pending",
-    resolution_callback = resolution_callback,
-    result_content = nil,
-    layout = "unified",
-    -- Track the originating MCP client so close_diffs_for_client can tear this
-    -- diff down if that client disconnects (parity with the native path, #261).
-    client_id = params.client_id,
-    -- Tab/window tracking
-    original_tab_number = original_tab_number,
-    created_new_tab = created_new_tab,
-    new_tab_number = new_tab_handle,
-    had_terminal_in_original = had_terminal_in_original,
-    terminal_win_in_new_tab = terminal_win_in_new_tab,
-    term_win = term_win,
-    term_width = term_width,
-  })
+    for _, ev in ipairs({ "BufDelete", "BufUnload", "BufWipeout" }) do
+      autocmd_ids[#autocmd_ids + 1] = vim.api.nvim_create_autocmd(ev, {
+        group = aug,
+        buffer = buf,
+        callback = function()
+          diff._resolve_diff_as_rejected(tab_name)
+        end,
+      })
+    end
+
+    diff._register_diff_state(tab_name, {
+      old_file_path = params.old_file_path,
+      new_file_path = params.new_file_path,
+      new_file_contents = params.new_file_contents,
+      new_buffer = buf,
+      new_window = diff_win,
+      target_window = editor_win,
+      fallback_window = fallback_window,
+      lines = lines,
+      line_types = line_types,
+      is_new_file = is_new_file,
+      autocmd_ids = autocmd_ids,
+      created_at = vim.fn.localtime(),
+      status = "pending",
+      resolution_callback = resolution_callback,
+      result_content = nil,
+      layout = "unified",
+      -- Track the originating MCP client so close_diffs_for_client can tear this
+      -- diff down if that client disconnects (parity with the native path, #261).
+      client_id = params.client_id,
+      -- Tab/window tracking
+      original_tab_number = original_tab_number,
+      created_new_tab = created_new_tab,
+      new_tab_number = new_tab_handle,
+      had_terminal_in_original = had_terminal_in_original,
+      terminal_win_in_new_tab = terminal_win_in_new_tab,
+      term_win = term_win,
+      term_width = term_width,
+    })
+  end)
 end
 
 -- ── Resolution functions ──────────────────────────────────────────
@@ -456,6 +570,10 @@ function M.cleanup_inline_diff(tab_name, diff_data)
     -- Close the diff split window
     if diff_data.new_window and vim.api.nvim_win_is_valid(diff_data.new_window) then
       pcall(vim.api.nvim_win_close, diff_data.new_window, true)
+    end
+
+    if diff_data.fallback_window and vim.api.nvim_win_is_valid(diff_data.fallback_window) then
+      pcall(vim.api.nvim_win_close, diff_data.fallback_window, false)
     end
 
     -- Restore terminal width

--- a/tests/unit/diff_auto_resize_events_spec.lua
+++ b/tests/unit/diff_auto_resize_events_spec.lua
@@ -137,6 +137,16 @@ describe("Diff lifecycle User events", function()
     return captured
   end
 
+  local function find_events(captured, pattern)
+    local events = {}
+    for _, e in ipairs(captured) do
+      if e.event == "User" and e.opts and e.opts.pattern == pattern then
+        events[#events + 1] = e
+      end
+    end
+    return events
+  end
+
   local function find_event(captured, pattern)
     for i = #captured, 1, -1 do
       local e = captured[i]
@@ -145,6 +155,38 @@ describe("Diff lifecycle User events", function()
       end
     end
     return nil
+  end
+
+  local function reset_to_terminal_only()
+    assert(vim and vim._mock and vim._mock.reset, "expected vim mock with _mock.reset()")
+
+    vim._mock.reset()
+    vim._tabs = { [1] = true }
+    vim._current_tabpage = 1
+    vim._current_window = 1000
+    vim._next_winid = 1001
+
+    vim._mock.add_buffer(1, "term://fake/claude", "", { buftype = "terminal", modified = false })
+    vim._mock.add_window(1000, 1, { 1, 0 })
+    vim._win_tab[1000] = 1
+    vim._tab_windows[1] = { 1000 }
+  end
+
+  local function reset_to_default_editor_window()
+    if not (vim and vim._mock and vim._mock.reset) then
+      return
+    end
+
+    vim._mock.reset()
+    vim._tabs = { [1] = true }
+    vim._current_tabpage = 1
+    vim._current_window = 1000
+    vim._next_winid = 1001
+
+    vim._mock.add_buffer(1, "/home/user/project/test.lua", "local test = {}\nreturn test")
+    vim._mock.add_window(1000, 1, { 1, 0 })
+    vim._win_tab[1000] = 1
+    vim._tab_windows[1] = { 1000 }
   end
 
   before_each(function()
@@ -163,8 +205,10 @@ describe("Diff lifecycle User events", function()
   end)
 
   after_each(function()
+    diff._cleanup_all_active_diffs("test_cleanup")
     package.loaded["claudecode.terminal"] = nil
     os.remove(test_old_file)
+    reset_to_default_editor_window()
   end)
 
   it("emits ClaudeCodeDiffOpened with the full payload when a diff opens", function()
@@ -198,6 +242,122 @@ describe("Diff lifecycle User events", function()
     vim.wait(100, function()
       return coroutine.status(co) == "dead"
     end)
+  end)
+
+  it("emits ClaudeCodeDiffOpened and ClaudeCodeDiffClosed for unified layout", function()
+    diff.setup({ terminal = {}, diff_opts = { layout = "unified" } })
+
+    local co = coroutine.create(function()
+      open_diff_tool.handler({
+        old_file_path = test_old_file,
+        new_file_path = test_old_file,
+        new_file_contents = "local a = 1\nlocal b = 42\nlocal c = 3\n",
+        tab_name = "opened-unified-tab",
+      })
+    end)
+    local opened_captured = capture_events(function()
+      local ok, err = coroutine.resume(co)
+      assert(ok, tostring(err))
+    end)
+
+    local opened_events = find_events(opened_captured, "ClaudeCodeDiffOpened")
+    assert.are.equal(1, #opened_events)
+    local opened_data = opened_events[1].opts.data
+    assert.are.equal("opened-unified-tab", opened_data.tab_name)
+    assert.are.equal(test_old_file, opened_data.file_path)
+    assert.are.equal(test_old_file, opened_data.new_file_path)
+    assert.is_false(opened_data.is_new_file)
+    assert.is_not_nil(opened_data.diff_window)
+    assert.is_true(vim.api.nvim_win_is_valid(opened_data.diff_window))
+    assert.is_not_nil(opened_data.target_window)
+    assert.is_true(vim.api.nvim_win_is_valid(opened_data.target_window))
+    assert.is_false(opened_events[1].opts.modeline)
+
+    local closed_captured = capture_events(function()
+      diff._cleanup_diff_state("opened-unified-tab", "diff rejected")
+    end)
+    local closed_events = find_events(closed_captured, "ClaudeCodeDiffClosed")
+    assert.are.equal(1, #closed_events)
+    local closed_data = closed_events[1].opts.data
+    assert.are.equal("opened-unified-tab", closed_data.tab_name)
+    assert.are.equal(test_old_file, closed_data.file_path)
+    assert.are.equal("diff rejected", closed_data.reason)
+  end)
+
+  it("emits unified ClaudeCodeDiffOpened with a valid target_window from a terminal-only tab", function()
+    reset_to_terminal_only()
+    assert.is_nil(diff._find_main_editor_window())
+    diff.setup({ terminal = {}, diff_opts = { layout = "unified" } })
+
+    local co = coroutine.create(function()
+      open_diff_tool.handler({
+        old_file_path = test_old_file,
+        new_file_path = test_old_file,
+        new_file_contents = "local a = 1\nlocal b = 43\nlocal c = 3\n",
+        tab_name = "opened-unified-terminal-only-tab",
+      })
+    end)
+    local opened_captured = capture_events(function()
+      local ok, err = coroutine.resume(co)
+      assert(ok, tostring(err))
+    end)
+
+    local opened_events = find_events(opened_captured, "ClaudeCodeDiffOpened")
+    assert.are.equal(1, #opened_events)
+    local opened_data = opened_events[1].opts.data
+    assert.is_not_nil(opened_data.diff_window)
+    assert.is_true(vim.api.nvim_win_is_valid(opened_data.diff_window))
+    assert.is_not_nil(opened_data.target_window)
+    assert.is_true(vim.api.nvim_win_is_valid(opened_data.target_window))
+    assert.are_not.equal(1000, opened_data.target_window)
+    local target_buf = vim.api.nvim_win_get_buf(opened_data.target_window)
+    assert.are_not.equal("terminal", vim.api.nvim_buf_get_option(target_buf, "buftype"))
+
+    local state = diff._get_active_diffs()["opened-unified-terminal-only-tab"]
+    assert.is_table(state)
+    assert.are.equal(opened_data.target_window, state.fallback_window)
+
+    diff._cleanup_diff_state("opened-unified-terminal-only-tab", "diff rejected")
+    assert.is_false(vim.api.nvim_win_is_valid(opened_data.target_window))
+    assert.is_true(vim.api.nvim_win_is_valid(1000))
+    reset_to_default_editor_window()
+  end)
+
+  it("cleans up a terminal-only unified fallback when setup fails before state registration", function()
+    reset_to_terminal_only()
+    assert.is_nil(diff._find_main_editor_window())
+    diff.setup({ terminal = {}, diff_opts = { layout = "unified" } })
+
+    local original_cmd = vim.cmd
+    local vsplit_count = 0
+    vim.cmd = function(command)
+      if command == "rightbelow vsplit" then
+        vsplit_count = vsplit_count + 1
+        if vsplit_count == 2 then
+          error("forced unified setup failure after fallback split")
+        end
+      end
+      return original_cmd(command)
+    end
+
+    local co = coroutine.create(function()
+      open_diff_tool.handler({
+        old_file_path = test_old_file,
+        new_file_path = test_old_file,
+        new_file_contents = "local a = 1\nlocal b = 44\nlocal c = 3\n",
+        tab_name = "failed-unified-terminal-only-tab",
+      })
+    end)
+    local ok = coroutine.resume(co)
+    vim.cmd = original_cmd
+
+    assert.is_false(ok)
+    assert.are.equal(2, vsplit_count)
+    assert.is_nil(diff._get_active_diffs()["failed-unified-terminal-only-tab"])
+    assert.is_true(vim.api.nvim_win_is_valid(1000))
+    local wins = vim.api.nvim_list_wins()
+    assert.are.equal(1, #wins)
+    assert.are.equal(1000, wins[1])
   end)
 
   it("emits ClaudeCodeDiffClosed with tab_name/file_path/reason on cleanup", function()


### PR DESCRIPTION
## Summary

Fixes #296.

- Emit `ClaudeCodeDiffOpened` for `diff_opts.layout = "unified"` after the unified diff state is registered.
- Emit `ClaudeCodeDiffClosed` from unified diff cleanup with the same payload shape as native layouts.
- Track a valid unified `target_window`, including the terminal-only fallback case, and add focused regression coverage.

## Validation

- `mise exec -- busted -v tests/unit/diff_auto_resize_events_spec.lua` — 15 successes / 0 failures.
- `mise exec -- busted -v tests/unit/diff_inline_spec.lua tests/unit/diff_auto_resize_events_spec.lua` — 41 successes / 0 failures.
- `mise run check` — 0 warnings / 0 errors in 113 files.
- `mise run test` — 705 successes / 0 failures.

## Dogfooding

- Headless Neovim dogfood passed with `mise exec -- nvim --headless -u NONE -l /tmp/repro_issue_296_headless.lua`.
- Terminal transcript recorded at `/tmp/issue-296-headless.typescript` and asciinema cast recorded at `/tmp/issue-296-headless.cast`; the run printed one `ClaudeCodeDiffOpened`, one `ClaudeCodeDiffClosed`, and `HEADLESS_DOGFOOD_OK`.
- Interactive screenshots were not available in this workspace because `DISPLAY` is empty.

## Workflow verifier summary

The issue implementation workflow converged without recovery. Its verifier found no issue-scope correctness defects after the fix and confirmed unified lifecycle parity plus the terminal-only fallback coverage.

---

<details>
<summary>📋 Implementation Plan</summary>

# Implementation Plan for coder/claudecode.nvim#296

## Issue Summary

GitHub issue `coder/claudecode.nvim#296` is an accepted bug: when users set `diff_opts.layout = "unified"`, the unified diff UI opens and closes without firing the documented `User` autocmd lifecycle events `ClaudeCodeDiffOpened` and `ClaudeCodeDiffClosed`.

Current live issue state verified with `gh issue view 296 --repo coder/claudecode.nvim --comments`:
- Title: `bug(diff): unified layout skips diff lifecycle User events`
- State: open
- Labels: `triage:done`, `bug`, `accepted`
- Impact: user autocmds for terminal resizing, statusline updates, or other review-lifecycle behavior work for native layouts but not unified layout.

## Verified Repository Context

Explore agents verified these current repo facts:

- `lua/claudecode/diff.lua` owns the native diff lifecycle orchestration and local `fire_diff_event(...)` helper.
- In `M._setup_blocking_diff`, the unified layout branch calls `require("claudecode.diff_inline").setup_inline_diff(params, resolution_callback, config)` and returns before the existing `ClaudeCodeDiffOpened` emission at the end of the native path.
- In `M._cleanup_diff_state`, the unified layout branch calls `diff_inline.cleanup_inline_diff(tab_name, diff_data)`, clears `active_diffs[tab_name]`, and returns before the existing `ClaudeCodeDiffClosed` emission.
- `lua/claudecode/diff_inline.lua` registers unified diff state through `diff._register_diff_state(tab_name, { ... })`, including `new_window = diff_win`, `layout = "unified"`, terminal/tab tracking fields, and local access to `editor_win` and `diff_win` at registration time.
- README and existing tests treat `ClaudeCodeDiffOpened` payload `target_window` as a non-nil field; only fields such as `terminal_window` and `tab_number` are optional/nilable. Therefore unified layout should provide a meaningful `target_window`, not `nil`.
- The best compatibility choice is `target_window = editor_win`, the original editor window used before the unified diff split is opened. This mirrors the native path's “original editor window” meaning.

## Scope Boundaries

In scope:
- Restore lifecycle event parity for `diff_opts.layout = "unified"`.
- Preserve existing payload shape as closely as possible to native vertical/horizontal diff layouts.
- Add focused regression coverage for unified open and close lifecycle events.

Out of scope:
- Reworking unified diff rendering, highlighting, folding, or accept/reject behavior.
- Renaming `diff_inline.lua` or changing layout naming semantics.
- Changing README event documentation unless implementation reveals an actual doc mismatch.
- Adding permanent repro scripts or fixtures unless tests cannot cover the behavior cleanly.

If implementation uncovers unrelated bugs or flaky behavior, follow the user's out-of-scope workflow: search existing issues first; comment with new evidence if a matching issue exists; otherwise create a `needs-triage` issue with reproduction/expected/actual details and link back to #296.

## Recommended Implementation Strategy

Use a small TDD loop: first add a failing regression test demonstrating that unified layout emits no lifecycle events, then make the smallest code change that passes it.

### Phase 1 — Add focused regression coverage

Modify `tests/unit/diff_auto_resize_events_spec.lua`.

Add one or two tests under the existing diff lifecycle User events coverage that:

1. Configure diff handling with `diff_opts.layout = "unified"`.
2. Open a diff via the same tool path used by existing lifecycle tests, e.g. `open_diff_tool.handler(...)` with:
   - `old_file_path = test_old_file`
   - `new_file_path = test_old_file`
   - changed `new_file_contents`
   - unique `tab_name`, e.g. `opened-unified-tab`
3. Capture calls to `vim.api.nvim_exec_autocmds` using the existing helper pattern.
4. Assert exactly one `ClaudeCodeDiffOpened` event is emitted with:
   - `tab_name`
   - `file_path`
   - `new_file_path`
   - `is_new_file == false` for the existing-file case
   - non-nil `diff_window`, and `vim.api.nvim_win_is_valid(diff_window)` if the harness still has the window open
   - non-nil `target_window`, and `vim.api.nvim_win_is_valid(target_window)` if the harness still has the window open
   - optional/nilable `terminal_window`; do not require a terminal window in the unit test
   - `modeline == false`
5. Resolve/reject or clean up the unified diff through one existing cleanup path only: prefer the same reject/accept resolver path used by existing lifecycle tests; use direct `_cleanup_diff_state(...)` only if that is the established pattern for this spec. Do not call both for the same active diff.
6. Capture and assert exactly one `ClaudeCodeDiffClosed` event is emitted with:
   - `tab_name`
   - `file_path`
   - the expected cleanup `reason`, such as `diff rejected` or the explicit test cleanup reason.

Quality gate after Phase 1:

```bash
mise exec -- busted -v tests/unit/diff_auto_resize_events_spec.lua
```

Expected before implementation: the new unified lifecycle test fails because the events are missing. If it does not fail, re-check the test harness before changing production code.

### Phase 2 — Preserve unified target-window state

Modify `lua/claudecode/diff_inline.lua` at the unified diff state registration in `M.setup_inline_diff(...)`.

Add the original editor window to registered state:

```lua
target_window = editor_win,
```

Place it next to `new_window = diff_win` so state fields align with native event payload concepts.

Rationale:
- `editor_win` is already in scope and represents the source editor window from which the unified split is created.
- Existing documentation and tests expect a non-nil `target_window` for opened events.
- Storing this in state lets `diff.lua` emit the event without exposing `fire_diff_event` to `diff_inline.lua`.

Defensive check guidance:
- Do not add broad runtime fallback behavior that hides bugs.
- If a local assertion/helper is already used in nearby code, it is reasonable to assert that `editor_win` is valid before storing it; otherwise keep the production change minimal and let the regression test prove the invariant.

Quality gate after Phase 2:

```bash
mise exec -- busted -v tests/unit/diff_inline_spec.lua tests/unit/diff_auto_resize_events_spec.lua
```

### Phase 3 — Emit `ClaudeCodeDiffOpened` for unified layout

Modify `lua/claudecode/diff.lua` inside the `layout == "unified"` branch of `M._setup_blocking_diff`.

After `inline.setup_inline_diff(params, resolution_callback, config)` returns and before the early `return`:

1. Read the registered state from `active_diffs[tab_name]`.
2. If state exists, call the existing local `fire_diff_event("ClaudeCodeDiffOpened", { ... })` helper.
3. Use payload values parallel to the native path:

```lua
fire_diff_event("ClaudeCodeDiffOpened", {
  tab_name = tab_name,
  file_path = params.old_file_path,
  new_file_path = params.new_file_path,
  is_new_file = state.is_new_file,
  diff_window = state.new_window,
  target_window = state.target_window,
  terminal_window = state.terminal_win_in_new_tab or find_claudecode_terminal_window(),
  tab_number = state.created_new_tab and state.new_tab_number or nil,
})
```

Implementation notes:
- Keep `fire_diff_event` private in `diff.lua`; do not expose `M._fire_diff_event` unless absolutely necessary.
- If `active_diffs[tab_name]` is absent because unified setup failed before registration, do not emit `ClaudeCodeDiffOpened`; a diff that failed to open should not report opened.
- Prefer `state.is_new_file` over recalculating if it is already stored by unified state; if the field is not present in the actual code, use the same `is_new_file` local already computed in `_setup_blocking_diff`.

Quality gate after Phase 3:

```bash
mise exec -- busted -v tests/unit/diff_auto_resize_events_spec.lua
```

### Phase 4 — Emit `ClaudeCodeDiffClosed` for unified layout

Modify `lua/claudecode/diff.lua` inside the `diff_data.layout == "unified"` branch of `M._cleanup_diff_state`.

After `inline.cleanup_inline_diff(tab_name, diff_data)` and `active_diffs[tab_name] = nil`, but before the early `return`, call:

```lua
fire_diff_event("ClaudeCodeDiffClosed", {
  tab_name = tab_name,
  file_path = diff_data.old_file_path,
  reason = reason,
})
```

Rationale:
- This preserves the existing native close payload shape.
- Emitting after unified cleanup mirrors the current native function ordering where closed events happen at the end of cleanup.
- The original `diff_data` remains available after cleanup, so payload construction does not require any additional state.

Quality gate after Phase 4:

```bash
mise exec -- busted -v tests/unit/diff_auto_resize_events_spec.lua tests/unit/diff_inline_spec.lua
```

### Phase 5 — Keep docs unchanged unless tests reveal a mismatch

The issue is that implementation does not meet the existing README lifecycle contract. The likely minimal fix is code plus regression tests only.

Only update docs if implementation reveals that README examples or field descriptions are inaccurate after the fix. Do not broaden this issue into documentation cleanup.

## Acceptance Criteria

The implementation is complete when all of these are true:

- With `diff_opts.layout = "unified"`, opening a proposed-edit diff fires exactly one `ClaudeCodeDiffOpened` User autocmd for that diff open.
- The unified `ClaudeCodeDiffOpened` payload includes the documented fields and mirrors native payload semantics:
  - `tab_name`
  - `file_path`
  - `new_file_path`
  - `is_new_file`
  - non-nil `diff_window` that is a valid Neovim window at emission time
  - non-nil `target_window` that is a valid Neovim window at emission time
  - `terminal_window` when discoverable, otherwise nil as currently allowed
  - `tab_number` only when the diff opens in a new tab
- With `diff_opts.layout = "unified"`, accepting, rejecting, or cleaning up the diff fires exactly one `ClaudeCodeDiffClosed` User autocmd.
- The unified `ClaudeCodeDiffClosed` payload includes `tab_name`, `file_path`, and `reason` with the same semantics as native layouts.
- Native vertical/horizontal diff lifecycle event behavior remains unchanged.
- Existing unified diff rendering and cleanup behavior remains unchanged except for lifecycle event emission.
- Regression tests fail on the current bug and pass after the fix.
- No unrelated issues are fixed or refactored as part of this work.

## Validation Plan

Run validation in this order, fixing any failures before claiming success:

1. Focused lifecycle test during development:

   ```bash
   mise exec -- busted -v tests/unit/diff_auto_resize_events_spec.lua
   ```

2. Unified diff suite and lifecycle suite together:

   ```bash
   mise exec -- busted -v tests/unit/diff_inline_spec.lua tests/unit/diff_auto_resize_events_spec.lua
   ```

3. Static checks:

   ```bash
   mise run check
   ```

4. Full test suite before PR/readiness handoff:

   ```bash
   mise run test
   ```

5. Optional formatting if files are changed in a way that may need formatting:

   ```bash
   mise run format
   ```

If the repo reports a mise trust error, run `mise trust` once from the repository root and retry the command.

## Dogfooding / Manual Verification Plan

Because this change affects an interactive Neovim lifecycle surface, produce reviewable evidence in addition to automated tests.

### Headless dogfood script, no committed fixture required

Use a temporary Lua script outside tracked files, e.g. `mktemp`, that:

1. Prepends the repo root to `runtimepath`.
2. Requires `claudecode.diff` and `claudecode.tools.open_diff`.
3. Creates a temporary file with simple Lua content.
4. Calls `diff.setup({ terminal = {}, diff_opts = { layout = "unified" } })`.
5. Registers `User` autocmd listeners for `ClaudeCodeDiffOpened` and `ClaudeCodeDiffClosed` that print compact `vim.inspect(ev.data)` payloads.
6. Starts `open_diff_tool.handler(...)` in a coroutine with changed file contents.
7. Rejects or cleans up the diff.
8. Exits non-zero if either event was not observed.

Run it with:

```bash
nvim --headless -u NONE -l /path/to/temp/repro_issue_296.lua
```

Capture terminal output with either:

```bash
script -q /tmp/issue-296-headless.typescript -c 'nvim --headless -u NONE -l /path/to/temp/repro_issue_296.lua'
```

or an equivalent terminal recording tool such as `asciinema rec` if available. Attach the transcript/recording or paste the relevant output in the PR notes.

### Interactive Neovim dogfood with visual evidence

For a reviewer-friendly UI check:

1. Create a temporary minimal config outside tracked files that sets:

   ```lua
   vim.opt.runtimepath:prepend(vim.fn.getcwd())
   require("claudecode").setup({
     diff_opts = { layout = "unified" },
   })
   vim.api.nvim_create_autocmd("User", {
     pattern = "ClaudeCodeDiffOpened",
     callback = function(ev)
       vim.notify("ClaudeCodeDiffOpened " .. vim.inspect(ev.data), vim.log.levels.INFO)
     end,
   })
   vim.api.nvim_create_autocmd("User", {
     pattern = "ClaudeCodeDiffClosed",
     callback = function(ev)
       vim.notify("ClaudeCodeDiffClosed " .. vim.inspect(ev.data), vim.log.levels.INFO)
     end,
   })
   ```

2. Launch Neovim from the repo root with that config.
3. Trigger a unified diff through the plugin/tool path or a small local command that invokes `open_diff_tool.handler(...)`.
4. Accept or reject the diff.
5. Capture:
   - screenshot of the unified diff UI after `ClaudeCodeDiffOpened` notification appears;
   - screenshot of the `ClaudeCodeDiffClosed` notification or `:messages` output after accepting/rejecting;
   - short terminal/video recording showing the open → event → close → event sequence.

Suggested capture options:
- `asciinema rec /tmp/issue-296-dogfood.cast` for terminal UI recording.
- `script` transcript if asciinema is unavailable.
- If a GUI/display is available, take screenshots and attach them to the PR using the repository's normal image attachment flow.

If the environment is headless and screenshots are not possible, explicitly report that blocker and provide the headless transcript/recording as the reviewable evidence.

## Risks and Mitigations

- **Duplicate event emission:** Add tests that capture event count or use unique tab names so the implementation proves exactly one open and one close event for unified layout.
- **Incorrect `target_window` semantics:** Use `editor_win` from `diff_inline.setup_inline_diff` because it is the original editor window and matches the native payload's intent. Assert it is non-nil in tests.
- **Event emitted before state/window is usable:** Emit `ClaudeCodeDiffOpened` only after `setup_inline_diff` registers state; emit `ClaudeCodeDiffClosed` after `cleanup_inline_diff` completes but before returning.
- **User autocmd errors affecting diff flow:** Reuse existing `fire_diff_event`, which already centralizes event execution behavior, rather than duplicating raw `nvim_exec_autocmds` calls.
- **Over-broad changes:** Keep edits limited to `lua/claudecode/diff.lua`, `lua/claudecode/diff_inline.lua`, and `tests/unit/diff_auto_resize_events_spec.lua` unless validation reveals a directly related need.

## Implementation Checklist

- [ ] Add failing unified lifecycle regression test(s) in `tests/unit/diff_auto_resize_events_spec.lua`.
- [ ] Store `target_window = editor_win` in unified diff state registration in `lua/claudecode/diff_inline.lua`.
- [ ] Emit `ClaudeCodeDiffOpened` in the unified branch of `M._setup_blocking_diff` in `lua/claudecode/diff.lua` after state registration.
- [ ] Emit `ClaudeCodeDiffClosed` in the unified branch of `M._cleanup_diff_state` in `lua/claudecode/diff.lua` before returning.
- [ ] Run focused and full validation commands.
- [ ] Dogfood with headless and, if possible, interactive evidence; attach transcript/screenshots/recording to the PR notes.

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.5` • Thinking: `xhigh`_
